### PR TITLE
MAINT: Remove ADO label

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -49,7 +49,3 @@
 - name: aps
   description: aps.
   color: db8af7
-
-- name: ado
-  description: ado.
-  color: d0cef7


### PR DESCRIPTION
Removes ADO label, as it is redundant with APS label.