### PR TITLE
FEAT: add pytest-xvfb plugin

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -137,7 +137,6 @@ jobs:
           ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER )}}
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
-          requires-xvfb: true
       
       - name: Upload PyVista generated images (cache and results)
         if: always()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ tests = [
   "pytest==7.4.0",
   "pytest-cov==4.1.0",
   "pytest-pyvista==0.1.8",
+  "pytest-xvfb==3.0.0",
   "pyvista[trame]==0.41.1"
 ]
 doc = [


### PR DESCRIPTION
Substitute `xvfb-run` command in favour of the `pytest-xvfb` plugin, that eases configuration and specific cases where you want or do not want to use the `xvfb` server.