### PR TITLE
Fix: Change default logger level to ERROR

### DIFF
--- a/src/ansys/meshing/prime/core/model.py
+++ b/src/ansys/meshing/prime/core/model.py
@@ -19,7 +19,7 @@ from ansys.meshing.prime.core.controldata import ControlData
 from ansys.meshing.prime.core.part import Part
 from ansys.meshing.prime.internals.communicator import Communicator
 from ansys.meshing.prime.internals.error_handling import PrimeRuntimeError
-from ansys.meshing.prime.internals.logger import LOG
+from ansys.meshing.prime.internals.logger import PrimeLogger
 
 
 class Model(_Model):
@@ -369,4 +369,4 @@ class Model(_Model):
         >>> model.python_logger.setLevel(logging.DEBUG)
 
         """
-        return LOG
+        return PrimeLogger().get_logger()

--- a/src/ansys/meshing/prime/internals/logger.py
+++ b/src/ansys/meshing/prime/internals/logger.py
@@ -86,6 +86,3 @@ class PrimeLogger(object, metaclass=SingletonType):
         file_handler = logging.FileHandler(logs_dir + "/log_" + now.strftime("%Y-%m-%d") + ".log")
         file_handler.setFormatter(self._formatter)
         self._logger.addHandler(file_handler)
-
-
-LOG = PrimeLogger().get_logger()

--- a/src/ansys/meshing/prime/internals/logger.py
+++ b/src/ansys/meshing/prime/internals/logger.py
@@ -31,8 +31,8 @@ class PrimeLogger(object, metaclass=SingletonType):
 
     def __init__(self, level: int = logging.ERROR, logger_name: str = "PyPrimeMesh"):
         """Logger initializer."""
-        self._logger = logging.getLogger(level)
-        self._logger.setLevel(logging.DEBUG)
+        self._logger = logging.getLogger(logger_name)
+        self._logger.setLevel(level)
         self._formatter = logging.Formatter(
             '%(asctime)s \t [%(levelname)s | %(filename)s:%(lineno)s] > %(message)s'
         )

--- a/src/ansys/meshing/prime/internals/logger.py
+++ b/src/ansys/meshing/prime/internals/logger.py
@@ -29,9 +29,9 @@ class PrimeLogger(object, metaclass=SingletonType):
 
     _logger = None
 
-    def __init__(self, logger_name: str = "PyPrimeMesh"):
+    def __init__(self, level: int = logging.ERROR, logger_name: str = "PyPrimeMesh"):
         """Logger initializer."""
-        self._logger = logging.getLogger(logger_name)
+        self._logger = logging.getLogger(level)
         self._logger.setLevel(logging.DEBUG)
         self._formatter = logging.Formatter(
             '%(asctime)s \t [%(levelname)s | %(filename)s:%(lineno)s] > %(message)s'
@@ -46,6 +46,16 @@ class PrimeLogger(object, metaclass=SingletonType):
             Logger.
         """
         return self._logger
+
+    def set_level(self, level: int):
+        """Set logger output level.
+
+        Parameters
+        ----------
+        level : int
+            Level of the logger.
+        """
+        self._logger.setLevel(level=level)
 
     def enable_output(self, stream=None):
         """Enable logger output to given stream.


### PR DESCRIPTION
We are having unwanted printed messages from the logger, this might be caused by the default level of the logger being setted on DEBUG. It's changed it to ERROR.