### PR TITLE
feat: Add simple plotter

### DIFF
--- a/src/ansys/meshing/prime/core/fileio.py
+++ b/src/ansys/meshing/prime/core/fileio.py
@@ -29,7 +29,6 @@ from ansys.meshing.prime.autogen.fileiostructs import (
     SizeFieldFileReadResults,
     WriteSizeFieldParams,
 )
-from ansys.meshing.prime.core.model import Model
 from ansys.meshing.prime.params.primestructs import ErrorCode
 
 
@@ -44,7 +43,7 @@ class FileIO(_FileIO):
 
     __doc__ = _FileIO.__doc__
 
-    def __init__(self, model: Model):
+    def __init__(self, model: "Model"):
         """Initialize model and parent class."""
         self._model = model
         super().__init__(model)

--- a/src/ansys/meshing/prime/core/model.py
+++ b/src/ansys/meshing/prime/core/model.py
@@ -262,6 +262,13 @@ class Model(_Model):
         _Model.set_global_sizing_params(self, params)
         self._global_sf_params = params
 
+    def plot(self):
+        """Plot the model mesh."""
+        # Lazy import to avoid circular imports.
+        from ansys.meshing.prime.graphics.simple_plotter import plot
+
+        plot(self)
+
     def __str__(self):
         """Print the summary of the model.
 

--- a/src/ansys/meshing/prime/graphics/simple_plotter.py
+++ b/src/ansys/meshing/prime/graphics/simple_plotter.py
@@ -1,0 +1,57 @@
+"""Simple plotter module."""
+import os
+import tempfile
+
+import pyvista as pv
+
+from ansys.meshing.prime.autogen.fileiostructs import ExportSTLParams
+from ansys.meshing.prime.core.fileio import FileIO
+
+
+class SimplePlotter:
+    """Simple plotter that export the model as STL to show it.
+
+    Exports the model as STL file and the loads this file with
+    PyVista directly to be able to visualize large meshes.
+
+    Parameters
+    ----------
+    model : prime.Model
+        Model we want to plot.
+    """
+
+    def __init__(self, model: "prime.Model") -> None:
+        """Initialize the plotter variables."""
+        self._model = model
+        self._fileio = FileIO(model)
+        self._tempdir = tempfile.gettempdir()
+        self._tmpfile = os.path.join(self._tempdir, "output.stl")
+        self._export_stl()
+
+    def _get_part_ids(self):
+        """Return all the parts of a model."""
+        return [part.id for part in self._model.parts]
+
+    def _export_stl(self):
+        """Export the model to STL format in tmp folder."""
+        part_ids = self._get_part_ids()
+        self._fileio.export_stl(
+            self._tmpfile, params=ExportSTLParams(self._model, part_ids=part_ids)
+        )
+
+    def plot_stl(self):
+        """Plot the stl file with PyVista."""
+        mesh = pv.read(self._tmpfile)
+        _ = mesh.plot(show_edges=True)
+
+
+def plot(model: "prime.Model"):
+    """Plot the given model in a simple PyVista plotter.
+
+    Parameters
+    ----------
+    model : prime.Model
+        The model you want to plot.
+    """
+    sp = SimplePlotter(model)
+    sp.plot_stl()


### PR DESCRIPTION
## Overview

While exporting a PMDAT file to STL, I noticed that if you load the STL file back with PyVista, everything seems to work fine. There is probably some issue with the plotter that we are not noticing. While I don't work in the plotter, this PR allows to visualize large models, as the ones shared by @hlee0122 with me. 

## Visual Example

Still not the smoothest experience but at least usable.

![Recording 2023-09-22 at 13 21 14](https://github.com/ansys/pyprimemesh/assets/17165476/3fbb0919-6a41-4cc5-8174-4e00befe7239)

## Example usage script
Added a plot method directly to `Model` class, I think it's more intuitive.

```python
import os
import tempfile

import ansys.meshing.prime as prime
from ansys.meshing.prime.graphics import Graphics

prime_client = prime.launch_prime()
model = prime_client.model

file_io = prime.FileIO(model)
file_io.read_pmdat(
    file_name="12M_mesh_non-confidential.pmdat",
    file_read_params=prime.FileReadParams(
        model=model
    )
)
model.plot()


```
