### PR TITLE
doc: Remove rule that is not working as expected

### DIFF
--- a/doc/.vale.ini
+++ b/doc/.vale.ini
@@ -26,6 +26,6 @@ Vocab = ANSYS
 
 # Apply the following styles
 BasedOnStyles = Vale, Google
-
+Google.Headings = NO
 # Inline roles are ignored
 TokenIgnores = (:.*:`.*`)|(<.*>)


### PR DESCRIPTION
Google Headings rule is not working as expected. It is raising a warning in sentences that are fine. For example:


Should work and fails:
```
This is a heading
```

Shouldn't work and passes:
```
this is a heading
```
For the time being we should remove this rule.

