### PR TITLE
Use simple verbs in example titles

### DIFF
--- a/doc/changelog.d/796.miscellaneous.md
+++ b/doc/changelog.d/796.miscellaneous.md
@@ -1,0 +1,1 @@
+Use simple verbs in example titles

--- a/examples/gallery/00_lucid_file_IO.py
+++ b/examples/gallery/00_lucid_file_IO.py
@@ -23,9 +23,9 @@
 """
 .. _ref_file_io:
 
-===================================================================
-Data conversion when importing and exporting mesh and CAD formats
-===================================================================
+==============================================================
+Convert data when importing and exporting mesh and CAD formats
+==============================================================
 
 **Summary**: This example shows how mesh and geometry formats are converted
 during import and export.

--- a/examples/gallery/01_bracket_scaffold.py
+++ b/examples/gallery/01_bracket_scaffold.py
@@ -23,9 +23,9 @@
 """
 .. _ref_bracket_mid_surface_mesh:
 
-========================================================
-Meshing a mid-surfaced bracket for a structural analysis
-========================================================
+=====================================================
+Mesh a mid-surfaced bracket for a structural analysis
+=====================================================
 
 **Summary**: This example demonstrates how to use topology-based connection
 to generate conformal surface mesh.

--- a/examples/gallery/02_lucid_mixing_elbow.py
+++ b/examples/gallery/02_lucid_mixing_elbow.py
@@ -23,9 +23,9 @@
 """
 .. _ref_mixing_elbow_mesh:
 
-==========================================
-Meshing a mixing elbow for a flow analysis
-==========================================
+=======================================
+Mesh a mixing elbow for a flow analysis
+=======================================
 
 **Summary**: This example demonstrates how to mesh a mixing elbow for a flow analysis.
 

--- a/examples/gallery/03_lucid_pipe_tee.py
+++ b/examples/gallery/03_lucid_pipe_tee.py
@@ -23,9 +23,9 @@
 """
 .. _ref_pipe_tee:
 
-=======================================================================
-Meshing a pipe T-section for structural thermal and fluid flow analysis
-=======================================================================
+====================================================================
+Mesh a pipe T-section for structural thermal and fluid flow analysis
+====================================================================
 
 **Summary**: This example demonstrates how to mesh a pipe T-section for both
 structural thermal and fluid flow simulation.

--- a/examples/gallery/04_lucid_toy_car.py
+++ b/examples/gallery/04_lucid_toy_car.py
@@ -23,9 +23,9 @@
 """
 .. _ref_toy_car_wrap:
 
-======================================
-Wrapping a toy car for a flow analysis
-======================================
+==================================
+Wrap a toy car for a flow analysis
+==================================
 
 **Summary**: This example demonstrates how to wrap a toy car for a flow analysis.
 

--- a/examples/gallery/05_pcb_stacker.py
+++ b/examples/gallery/05_pcb_stacker.py
@@ -23,9 +23,9 @@
 """
 .. _ref_pcb:
 
-=============================================
-Meshing a PCB for structural thermal analysis
-=============================================
+==========================================
+Mesh a PCB for structural thermal analysis
+==========================================
 
 **Summary**: This example demonstrates how to mesh a printed circuit board
 with mainly hexahedral elements for structural thermal simulation using the volume sweeper.

--- a/examples/gallery/06_blade_morph.py
+++ b/examples/gallery/06_blade_morph.py
@@ -23,9 +23,9 @@
 """
 .. _ref_turbine_blade:
 
-============================================================
-Morphing a hexahedral mesh of a turbine blade to a new shape
-============================================================
+=========================================================
+Morph a hexahedral mesh of a turbine blade to a new shape
+==========================================================
 
 **Summary**: This example demonstrates how to morph a structural
 hexahedral mesh of a turbine blade to a new deformed shape

--- a/examples/gallery/06_blade_morph.py
+++ b/examples/gallery/06_blade_morph.py
@@ -25,7 +25,7 @@
 
 =========================================================
 Morph a hexahedral mesh of a turbine blade to a new shape
-==========================================================
+=========================================================
 
 **Summary**: This example demonstrates how to morph a structural
 hexahedral mesh of a turbine blade to a new deformed shape

--- a/examples/gallery/07_saddle_bracket.py
+++ b/examples/gallery/07_saddle_bracket.py
@@ -23,9 +23,9 @@
 """
 .. _ref_saddle_thin_hex:
 
-==================================================
-Meshing a saddle bracket for a structural analysis
-==================================================
+===============================================
+Mesh a saddle bracket for a structural analysis
+===============================================
 
 **Summary**: This example demonstrates how to mesh a thin
 solid with hexahedral and prism cells.

--- a/examples/gallery/08_lucid_generic_f1_rear_wing.py
+++ b/examples/gallery/08_lucid_generic_f1_rear_wing.py
@@ -23,9 +23,9 @@
 """
 .. _ref_generic_f1_rw:
 
-================================================================
-Meshing a generic F1 car rear wing for external aero simulation
-================================================================
+=============================================================
+Mesh a generic F1 car rear wing for external aero simulation
+=============================================================
 
 **Summary**: This example demonstrates how to generate a mesh for a generic F1 rear wing
 STL file model.

--- a/examples/gallery/09_multi_layer_quad_mesh_pcb.py
+++ b/examples/gallery/09_multi_layer_quad_mesh_pcb.py
@@ -23,9 +23,9 @@
 """
 .. _ref_multi_layer_pcb_mesh:
 
-========================================================
-Meshing a generic PCB geometry with multiple hexa layers
-========================================================
+=====================================================
+Mesh a generic PCB geometry with multiple hexa layers
+=====================================================
 
 **Summary**: This example demonstrates how to set the base mesh size and number of
 layers for each solid in a generic PCB geometry and then generate a mesh.

--- a/examples/misc/example_template.py
+++ b/examples/misc/example_template.py
@@ -23,8 +23,8 @@
 """
 .. _ref_how_to_add_an_example_reference_key:
 
-Adding a new example
---------------------
+Add a new example
+-----------------
 **Summary**: This example demonstrates how to add new examples and serves as a template
 that you can use in their creation.
 


### PR DESCRIPTION
Style guide recommends the use of simple verbs for titles and headings. The use of simple verbs also helps with search engine optimization.