### PR TITLE
Fix link to the lucid API doc in the user guide

### DIFF
--- a/doc/changelog.d/809.miscellaneous.md
+++ b/doc/changelog.d/809.miscellaneous.md
@@ -1,0 +1,1 @@
+Fix link to the lucid API doc in the user guide

--- a/doc/source/user_guide/lucid.rst
+++ b/doc/source/user_guide/lucid.rst
@@ -4,13 +4,13 @@
 Common meshing tasks and the Lucid module
 *****************************************
 
-The `lucid <https://prime.docs.pyansys.com/version/stable/api/_autosummary/ansys.meshing.prime.lucid.html>` module defines high-level methods to abstract
+The `lucid <https://prime.docs.pyansys.com/version/stable/api/_autosummary/ansys.meshing.prime.lucid.html>`_ module defines high-level methods to abstract
 and simplify common meshing tasks. Methods contained in this module are intended to demonstrate
 how the low-level APIs can be combined to execute meshing workflows flexibly and with minimal
 need for understanding PyPrimeMesh-specific concepts. The methods use global automatic defaults
 where possible to reduce effort in creating general purpose operations.
 
-Many common meshing tasks and workflows can be tackled easily using the functions provided.  
+Many common meshing tasks and workflows can be tackled easily using the functions provided.
 
 Here is an example of meshing the mixing elbow case for a fluid flow analysis:
 


### PR DESCRIPTION
Tiny fix: Add a missing underscore to make the link valid reStructuredText.