### PR TITLE
fix: Slow plotting

### DIFF
--- a/doc/changelog.d/861.fixed.md
+++ b/doc/changelog.d/861.fixed.md
@@ -1,0 +1,1 @@
+fix: Slow plotting

--- a/examples/gallery/00_lucid_file_IO.py
+++ b/examples/gallery/00_lucid_file_IO.py
@@ -145,13 +145,13 @@ display.show()
 
 mesh_util.surface_mesh(min_size=2.0)
 display = PrimePlotter()
-display.plot(model)
+display.plot(model, update=True)
 display.show()
 
 part = model.get_part_by_name("pyprime_block_import")
 
 display = PrimePlotter()
-display.add_scope(model, prime.ScopeDefinition(model, label_expression="my_group"))
+display.plot(model, prime.ScopeDefinition(model, label_expression="my_group"))
 display.show()
 
 mesh_util.volume_mesh()
@@ -279,7 +279,7 @@ for zone in part.get_face_zones():
         zone_expression=model.get_zone_name(zone),
     )
     display = PrimePlotter()
-    display.add_scope(model, scope)
+    display.plot(model, scope, update=True)
     display.show()
 
 ###############################################################################

--- a/examples/gallery/01_bracket_scaffold.py
+++ b/examples/gallery/01_bracket_scaffold.py
@@ -154,7 +154,7 @@ surfer_result = prime.Surfer(model).mesh_topo_faces(part.id, topo_faces=faces, p
 
 # Display the mesh
 pl = PrimePlotter()
-pl.plot(model)
+pl.plot(model, update=True)
 pl.show()
 
 ###############################################################################

--- a/examples/gallery/03_lucid_pipe_tee.py
+++ b/examples/gallery/03_lucid_pipe_tee.py
@@ -112,7 +112,7 @@ if toDelete:
     model.delete_parts(toDelete)
 
 display = PrimePlotter()
-display.plot(model)
+display.plot(model, update=True)
 display.show()
 
 ###############################################################################
@@ -153,7 +153,7 @@ wrap = mesh_util.wrap(min_size=6, region_extract=prime.WrapRegion.LARGESTINTERNA
 print(model)
 
 display = PrimePlotter()
-display.add_model(model)
+display.add_model(model, update=True)
 display.show()
 
 ###############################################################################
@@ -179,7 +179,9 @@ mesh_util.volume_mesh(
 
 print(model)
 display = PrimePlotter()
-display.add_scope(model, scope=prime.ScopeDefinition(model=model, label_expression="* !*__*"))
+display.add_scope(
+    model, scope=prime.ScopeDefinition(model=model, label_expression="* !*__*"), update=True
+)
 display.show()
 
 ###############################################################################

--- a/examples/gallery/03_lucid_pipe_tee.py
+++ b/examples/gallery/03_lucid_pipe_tee.py
@@ -112,7 +112,7 @@ if toDelete:
     model.delete_parts(toDelete)
 
 display = PrimePlotter()
-display.add_model(model)
+display.plot(model)
 display.show()
 
 ###############################################################################

--- a/examples/gallery/04_lucid_toy_car.py
+++ b/examples/gallery/04_lucid_toy_car.py
@@ -65,10 +65,12 @@ Procedure
 
 import os
 import tempfile
+import time
 
 import ansys.meshing.prime as prime
 from ansys.meshing.prime.graphics import PrimePlotter
 
+total_time = time.time()
 prime_client = prime.launch_prime()
 model = prime_client.model
 
@@ -90,7 +92,10 @@ mesh_util.read(file_name=toy_car)
 
 scope = prime.ScopeDefinition(model, part_expression="* !*tunnel*")
 pl = PrimePlotter()
+start_time = time.time()
 pl.plot(model, scope)
+end_time = time.time()
+total_time += end_time - start_time
 pl.show()
 ###############################################################################
 # Close holes
@@ -108,7 +113,10 @@ for part_name in coarse_wrap:
     # Each open part before wrap
     scope = prime.ScopeDefinition(model, part_expression=part_name)
     pl = PrimePlotter()
+    start_time = time.time()
     pl.plot(model, scope)
+    end_time = time.time()
+    total_time += end_time - start_time
     pl.show()
     closed_part = mesh_util.wrap(
         input_parts=part_name,
@@ -119,8 +127,13 @@ for part_name in coarse_wrap:
     # Closed part with no hole
     scope = prime.ScopeDefinition(model, part_expression=closed_part.name)
     pl = PrimePlotter()
+    start_time = time.time()
     pl.plot(model, scope)
+    end_time = time.time()
     pl.show()
+
+
+print("Total time for wrapping: ", total_time)
 
 ###############################################################################
 # Extract fluid using a wrapper

--- a/examples/gallery/04_lucid_toy_car.py
+++ b/examples/gallery/04_lucid_toy_car.py
@@ -65,12 +65,10 @@ Procedure
 
 import os
 import tempfile
-import time
 
 import ansys.meshing.prime as prime
 from ansys.meshing.prime.graphics import PrimePlotter
 
-total_time = time.time()
 prime_client = prime.launch_prime()
 model = prime_client.model
 
@@ -92,10 +90,7 @@ mesh_util.read(file_name=toy_car)
 scope = prime.ScopeDefinition(model, part_expression="* !*tunnel*")
 
 pl = PrimePlotter()
-start_time = time.time()
 pl.plot(model, scope)
-end_time = time.time()
-total_time += end_time - start_time
 pl.show()
 ###############################################################################
 # Close holes
@@ -113,10 +108,7 @@ for part_name in coarse_wrap:
     # Each open part before wrap
     scope = prime.ScopeDefinition(model, part_expression=part_name)
     pl = PrimePlotter()
-    start_time = time.time()
     pl.plot(model, scope)
-    end_time = time.time()
-    total_time += end_time - start_time
     pl.show()
     closed_part = mesh_util.wrap(
         input_parts=part_name,
@@ -127,13 +119,9 @@ for part_name in coarse_wrap:
     # Closed part with no hole
     scope = prime.ScopeDefinition(model, part_expression=closed_part.name)
     pl = PrimePlotter()
-    start_time = time.time()
     pl.plot(model, scope)
-    end_time = time.time()
     pl.show()
 
-
-print("Total time for wrapping: ", total_time)
 
 ###############################################################################
 # Extract fluid using a wrapper

--- a/examples/gallery/05_pcb_stacker.py
+++ b/examples/gallery/05_pcb_stacker.py
@@ -149,7 +149,7 @@ base_scope = prime.lucid.SurfaceScope(
 mesh_util.surface_mesh(min_size=0.5, scope=base_scope, generate_quads=True)
 
 display = PrimePlotter()
-display.plot(model, scope=scope)
+display.plot(model, scope=scope, update=True)
 display.show()
 
 ###############################################################################
@@ -166,7 +166,7 @@ stackbase_results = sweeper.stack_base_face(
 )
 
 display = PrimePlotter()
-display.plot(model)
+display.plot(model, update=True)
 display.show()
 
 ###############################################################################

--- a/examples/gallery/06_blade_morph.py
+++ b/examples/gallery/06_blade_morph.py
@@ -130,7 +130,7 @@ morpher.match_morph(
 # Display the morphed mesh
 
 display = PrimePlotter()
-display.plot(model)
+display.plot(model, update=True)
 display.show()
 ###############################################################################
 # Write mesh

--- a/examples/gallery/07_saddle_bracket.py
+++ b/examples/gallery/07_saddle_bracket.py
@@ -109,7 +109,7 @@ mesh_util.surface_mesh(
 )
 
 display = PrimePlotter()
-display.plot(model)
+display.plot(model, update=True)
 display.show()
 
 ###############################################################################
@@ -147,7 +147,7 @@ mesh_util.surface_mesh(
 )
 
 display = PrimePlotter()
-display.plot(model)
+display.plot(model, update=True)
 display.show()
 
 ###############################################################################
@@ -219,7 +219,7 @@ result_vol = volume_mesh.mesh(part_id=part.id, automesh_params=auto_mesh_params)
 print(part.get_summary(prime.PartSummaryParams(model)))
 
 display = PrimePlotter()
-display.plot(model)
+display.plot(model, update=True)
 display.show()
 ###############################################################################
 # Write mesh

--- a/examples/gallery/08_lucid_generic_f1_rear_wing.py
+++ b/examples/gallery/08_lucid_generic_f1_rear_wing.py
@@ -318,7 +318,7 @@ print("\nMesh check", result, sep="\n")
 
 scope = prime.ScopeDefinition(model, part_expression="*", label_expression="* !*enclosure*")
 display = PrimePlotter()
-display.plot(model, scope)
+display.plot(model, scope, update=True)
 display.show()
 ###############################################################################
 # Write mesh

--- a/examples/gallery/09_multi_layer_quad_mesh_pcb.py
+++ b/examples/gallery/09_multi_layer_quad_mesh_pcb.py
@@ -244,7 +244,7 @@ mesh_util_controls = mesh_util.surface_mesh_with_size_controls(
 
 if display_intermediate_steps:
     display = PrimePlotter()
-    display.plot(model)
+    display.plot(model, update=True)
     display.show()
 
 ###############################################################################
@@ -269,7 +269,7 @@ stackbase_results = sweeper.stack_base_face(
 
 if display_intermediate_steps:
     display = PrimePlotter()
-    display.plot(model)
+    display.plot(model, update=True)
     display.show()
 ###############################################################################
 # Set up the zone naming before the mesh output

--- a/examples/gallery/10_wheel_ground_contact_patch.py
+++ b/examples/gallery/10_wheel_ground_contact_patch.py
@@ -177,9 +177,9 @@ wrap_part = mesh_util.wrap(
     wrap_size_controls=[size_control],
 )
 
-display = PrimePlotter()
-display.plot(model, scope=prime.ScopeDefinition(model, label_expression="ground, patch*, wheel"))
-display.show()
+# display = PrimePlotter()
+# display.plot(model, scope=prime.ScopeDefinition(model, label_expression="ground, patch*, wheel"))
+# display.show()
 
 print(model)
 
@@ -198,7 +198,11 @@ mesh_util.volume_mesh(
 )
 
 display = PrimePlotter()
-display.plot(model, scope=prime.ScopeDefinition(model, label_expression="!front !side_right !top"))
+display.plot(
+    model,
+    scope=prime.ScopeDefinition(model, label_expression="!front !side_right !top"),
+    update=True,
+)
 display.show()
 
 mesh_util.create_zones_from_labels()

--- a/src/ansys/meshing/prime/core/mesh.py
+++ b/src/ansys/meshing/prime/core/mesh.py
@@ -449,7 +449,7 @@ class Mesh(MeshInfo):
         if surf.n_points > 0:
             return MeshObjectPlot(part, surf)
 
-    def get_scoped_polydata(self, scope: "prime.ScopeDefinition", recalculate: bool = False):
+    def get_scoped_polydata(self, scope: "prime.ScopeDefinition", update: bool = False):
         """Get the polydata object of the scoped mesh.
 
         Parameters
@@ -462,7 +462,7 @@ class Mesh(MeshInfo):
         pv.PolyData
             PyVista mesh object.
         """
-        self.as_polydata()
+        self.as_polydata(update=update)
         parts = self._model.control_data.get_scope_parts(scope)
 
         # Update the polydata if any part is not in the dictionary
@@ -495,7 +495,7 @@ class Mesh(MeshInfo):
         # to get the updated changes from the backend
         if len(scoped_pd) == 0:
             self.__init__(self._model)
-            return self.get_scoped_polydata(scope, recalculate=True)
+            return self.get_scoped_polydata(scope, update=True)
         return scoped_pd
 
     def update_pd(self, part_ids) -> Dict[int, Dict[str, list[(pv.PolyData, Part)]]]:
@@ -511,9 +511,10 @@ class Mesh(MeshInfo):
         Dict[int, Dict[str, List[(pv.PolyData, Part)]]
             Dictionary with the polydata objects.
         """
-        facet_result = self.get_face_and_edge_connectivity(
-            part_ids, FaceAndEdgeConnectivityParams(model=self._model)
-        )
+        with prime.numpy_array_optimization_enabled():
+            facet_result = self.get_face_and_edge_connectivity(
+                part_ids, FaceAndEdgeConnectivityParams(model=self._model)
+            )
         self._parts_polydata = {}
         for i, part_id in enumerate(facet_result.part_ids):
             part = self._model.get_part(part_id)
@@ -545,17 +546,24 @@ class Mesh(MeshInfo):
         return self._parts_polydata
 
     def as_polydata(
-        self, recalculate: bool = True
+        self,
+        update: bool = False,
     ) -> Dict[int, Dict[str, List[tuple[pv.PolyData, Part]]]]:
         """Return the mesh as a ``pv.PolyData`` object.
+
+        Parameters
+        ----------
+        update : bool, default: False
+            Update the polydata.
 
         Returns
         -------
         Dict[int, Dict[str, List[(pv.PolyData, Part)]]
             Dictionary with the polydata objects.
         """
-        part_ids = [part.id for part in self._model.parts]
-        self.update_pd(part_ids)
+        if not self._parts_polydata or update:
+            part_ids = [part.id for part in self._model.parts]
+            self.update_pd(part_ids)
         return self._parts_polydata
 
     @property

--- a/src/ansys/meshing/prime/core/mesh.py
+++ b/src/ansys/meshing/prime/core/mesh.py
@@ -462,7 +462,7 @@ class Mesh(MeshInfo):
         pv.PolyData
             PyVista mesh object.
         """
-        self.as_polydata(recalculate)
+        self.as_polydata()
         parts = self._model.control_data.get_scope_parts(scope)
 
         # Update the polydata if any part is not in the dictionary
@@ -514,6 +514,7 @@ class Mesh(MeshInfo):
         facet_result = self.get_face_and_edge_connectivity(
             part_ids, FaceAndEdgeConnectivityParams(model=self._model)
         )
+        self._parts_polydata = {}
         for i, part_id in enumerate(facet_result.part_ids):
             part = self._model.get_part(part_id)
             splines = part.get_splines()
@@ -544,7 +545,7 @@ class Mesh(MeshInfo):
         return self._parts_polydata
 
     def as_polydata(
-        self, recalculate: bool = False
+        self, recalculate: bool = True
     ) -> Dict[int, Dict[str, List[tuple[pv.PolyData, Part]]]]:
         """Return the mesh as a ``pv.PolyData`` object.
 
@@ -553,9 +554,8 @@ class Mesh(MeshInfo):
         Dict[int, Dict[str, List[(pv.PolyData, Part)]]
             Dictionary with the polydata objects.
         """
-        if not self._parts_polydata and not recalculate:
-            part_ids = [part.id for part in self._model.parts]
-            self.update_pd(part_ids)
+        part_ids = [part.id for part in self._model.parts]
+        self.update_pd(part_ids)
         return self._parts_polydata
 
     @property

--- a/src/ansys/meshing/prime/core/mesh.py
+++ b/src/ansys/meshing/prime/core/mesh.py
@@ -450,7 +450,6 @@ class Mesh(MeshInfo):
             return MeshObjectPlot(part, surf)
 
     def get_scoped_polydata(self, scope: "prime.ScopeDefinition", update: bool = False):
-
         """Get the polydata object of the scoped mesh.
 
         Parameters
@@ -550,7 +549,6 @@ class Mesh(MeshInfo):
         self,
         update: bool = False,
     ) -> Dict[int, Dict[str, List[tuple[pv.PolyData, Part]]]]:
-
         """Return the mesh as a ``pv.PolyData`` object.
 
         Parameters

--- a/src/ansys/meshing/prime/core/model.py
+++ b/src/ansys/meshing/prime/core/model.py
@@ -451,6 +451,5 @@ class Model(_Model):
         --------
             >>> scoped_polydata = model.get_scoped_polydata(scope)
         """
-        if self._model_pv_mesh is None:
-            self._model_pv_mesh = Mesh(self)
+        self._model_pv_mesh = Mesh(self)
         return self._model_pv_mesh.get_scoped_polydata(scope)

--- a/src/ansys/meshing/prime/core/model.py
+++ b/src/ansys/meshing/prime/core/model.py
@@ -474,4 +474,3 @@ class Model(_Model):
         if self._model_pv_mesh is None or update:
             self._model_pv_mesh = Mesh(self)
         return self._model_pv_mesh.get_scoped_polydata(scope, update=update)
-

--- a/src/ansys/meshing/prime/core/model.py
+++ b/src/ansys/meshing/prime/core/model.py
@@ -419,8 +419,13 @@ class Model(_Model):
         """
         return PrimeLogger()
 
-    def as_polydata(self):
+    def as_polydata(self, update: bool = False):
         """Get the model as a polydata.
+
+        Parameters
+        ----------
+        update : bool, optional
+            Update the polydata if it is already present, by default False.
 
         Returns
         -------
@@ -431,10 +436,11 @@ class Model(_Model):
         --------
             >>> polydata = model.as_polydata()
         """
-        self._model_pv_mesh = Mesh(self)
-        return self._model_pv_mesh.as_polydata()
+        if self._model_pv_mesh is None or update:
+            self._model_pv_mesh = Mesh(self)
+        return self._model_pv_mesh.as_polydata(update=update)
 
-    def get_scoped_polydata(self, scope):
+    def get_scoped_polydata(self, scope, update: bool = False):
         """Get the scoped polydata of the model.
 
         Parameters
@@ -451,5 +457,6 @@ class Model(_Model):
         --------
             >>> scoped_polydata = model.get_scoped_polydata(scope)
         """
-        self._model_pv_mesh = Mesh(self)
-        return self._model_pv_mesh.get_scoped_polydata(scope)
+        if self._model_pv_mesh is None or update:
+            self._model_pv_mesh = Mesh(self)
+        return self._model_pv_mesh.get_scoped_polydata(scope, update=update)

--- a/src/ansys/meshing/prime/graphics/plotter.py
+++ b/src/ansys/meshing/prime/graphics/plotter.py
@@ -133,7 +133,9 @@ class PrimePlotter(Plotter):
         else:
             return color_matrix[mesh_info.zone_id % num_colors].tolist()
 
-    def add_model(self, model: Model, scope: prime.ScopeDefinition = None) -> None:
+    def add_model(
+        self, model: Model, scope: prime.ScopeDefinition = None, update: bool = False
+    ) -> None:
         """Add a Prime model to the plotter.
 
         Parameters
@@ -142,12 +144,14 @@ class PrimePlotter(Plotter):
             Prime model to add.
         scope : prime.ScopeDefinition, default: None
             Scope to show, if any.
+        update : bool, default: False
+            Whether to update the display.
         """
         if scope is None:
-            model_pd = model.as_polydata()
+            model_pd = model.as_polydata(update=update)
             self.add_model_pd(model_pd)
         else:
-            self.add_scope(model, scope)
+            self.add_scope(model, scope, update=update)
 
     def add_model_pd(self, model_pd: Dict) -> None:
         """Add a model to the plotter.
@@ -211,7 +215,7 @@ class PrimePlotter(Plotter):
                     spline_mesh_part.actor = actor
                     self._backend._object_to_actors_map[actor] = spline_mesh_part
 
-    def add_scope(self, model: Model, scope: prime.ScopeDefinition) -> None:
+    def add_scope(self, model: Model, scope: prime.ScopeDefinition, update: bool = False) -> None:
         """Add a scope to the plotter.
 
         Parameters
@@ -220,14 +224,17 @@ class PrimePlotter(Plotter):
             Model to add to the plotter.
         scope : prime.ScopeDefinition
             Scope to add to the plotter.
+        update : bool, default: False
+            Whether to update the display.
         """
-        model_pd = model.get_scoped_polydata(scope)
+        model_pd = model.get_scoped_polydata(scope, update=update)
         self.add_model_pd(model_pd)
 
     def plot_iter(
         self,
         plotting_list: List[Any],
         name_filter: str = None,
+        update: bool = False,
         **plotting_options,
     ) -> None:
         """
@@ -241,6 +248,8 @@ class PrimePlotter(Plotter):
             List of objects to plot.
         name_filter : str, default: None
             Regular expression with the desired name or names to include in the plotter.
+        update: bool, default: False
+            Whether to update the display.
         **plotting_options : dict, default: None
             Keyword arguments. For allowable keyword arguments, see the
             :meth:`Plotter.add_mesh <pyvista.Plotter.add_mesh>` method.
@@ -254,6 +263,7 @@ class PrimePlotter(Plotter):
         plottable_object: Any,
         scope: prime.ScopeDefinition = None,
         name_filter: str = None,
+        update: bool = False,
         **plotting_options,
     ):
         """Add an object to the plotter.
@@ -268,6 +278,8 @@ class PrimePlotter(Plotter):
             Scope to plot.
         name_filter : str, default: None
             Regular expression with the desired name or names to include in the plotter.
+        update: bool, default: False
+            Whether to update the display. Required when any mesh is updated.
         **plotting_options : dict, default: None
             Keyword arguments. For allowable keyword arguments, see the
             :meth:`Plotter.add_mesh <pyvista.Plotter.add_mesh>` method.
@@ -290,9 +302,9 @@ class PrimePlotter(Plotter):
 
         """
         if isinstance(plottable_object, Model):
-            self.add_model(plottable_object, scope)
+            self.add_model(plottable_object, scope, update=update)
         elif isinstance(plottable_object, List):
-            self.plot_iter(plottable_object, name_filter, **plotting_options)
+            self.plot_iter(plottable_object, name_filter, update=update, **plotting_options)
         else:
             self._backend.pv_interface.plot(plottable_object, name_filter, **plotting_options)
 


### PR DESCRIPTION
## Overview

This PR fixes the plotting operation being slow in the new PrimePlotter object. This is solved by caching some of the operations and updating only when required, after performing a meshing operation in the backend.