### PR TITLE
fix: PyVista deprecation

### DIFF
--- a/src/ansys/meshing/prime/core/mesh.py
+++ b/src/ansys/meshing/prime/core/mesh.py
@@ -325,7 +325,7 @@ class Mesh(MeshInfo):
         vertices, faces = self._get_vertices_and_surf_faces(face_facet_res, index)
         surf = pv.PolyData(vertices, faces)
         fcolor = np.array(self.get_face_color(part, ColorByType.ZONE))
-        colors = np.tile(fcolor, (surf.n_faces, 1))
+        colors = np.tile(fcolor, (surf.n_faces_strict, 1))
         surf["colors"] = colors
         surf.disp_mesh = self
         has_mesh = True
@@ -415,7 +415,7 @@ class Mesh(MeshInfo):
         faces = self.compute_face_list_from_structured_nodes(dim)
         surf = pv.PolyData(vertices, faces)
         fcolor = np.array([0, 0, 255])
-        colors = np.tile(fcolor, (surf.n_faces, 1))
+        colors = np.tile(fcolor, (surf.n_faces_strict, 1))
         surf["colors"] = colors
         surf.disp_mesh = self
         if surf.n_points > 0:
@@ -443,7 +443,7 @@ class Mesh(MeshInfo):
         faces = self.compute_face_list_from_structured_nodes(dim)
         surf = pv.PolyData(vertices, faces)
         fcolor = np.array(color_matrix[1])
-        colors = np.tile(fcolor, (surf.n_faces, 1))
+        colors = np.tile(fcolor, (surf.n_faces_strict, 1))
         surf["colors"] = colors
         surf.disp_mesh = self
         if surf.n_points > 0:

--- a/tests/test_lucid_toycar_wrapper_tutorial_regression.py
+++ b/tests/test_lucid_toycar_wrapper_tutorial_regression.py
@@ -103,7 +103,7 @@ def test_toycar_tutorial(get_remote_client, get_examples):
         prime.PartSummaryParams(model=model, print_id=False, print_mesh=True)
     )
     # Validate number of tri faces
-    assert math.isclose(178102.0, float(part_summary_res.n_faces), rel_tol=0.02)
+    assert math.isclose(178102.0, float(part_summary_res.n_faces_strict), rel_tol=0.02)
 
     mesher.create_zones_from_labels(
         """tunnel,cabin,outer,component21,component22,component24,component25,

--- a/tests/test_lucid_toycar_wrapper_tutorial_regression.py
+++ b/tests/test_lucid_toycar_wrapper_tutorial_regression.py
@@ -103,7 +103,7 @@ def test_toycar_tutorial(get_remote_client, get_examples):
         prime.PartSummaryParams(model=model, print_id=False, print_mesh=True)
     )
     # Validate number of tri faces
-    assert math.isclose(178102.0, float(part_summary_res.n_faces_strict), rel_tol=0.02)
+    assert math.isclose(178102.0, float(part_summary_res.n_faces), rel_tol=0.02)
 
     mesher.create_zones_from_labels(
         """tunnel,cabin,outer,component21,component22,component24,component25,


### PR DESCRIPTION
This should fix the deprecation warnings that are appearing in the examples.