### PR TITLE
feature: Enable parallel execution of example scripts before Sphinx build

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -49,6 +49,7 @@ jobs:
       - uses: ansys/actions/check-vulnerabilities@v10.0.3
         with:
           upload-reports: true
+          hide-log: false
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
           python-package-name: ${{ env.PACKAGE_NAME }}

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -102,7 +102,8 @@ jobs:
   docs:
     name: Documentation
     if: github.event.action != 'closed'
-    runs-on: public-ubuntu-latest-16-cores
+    # runs-on: public-ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     needs: [docs-style]
     steps:
       - name: Login in Github Container registry
@@ -126,7 +127,7 @@ jobs:
           needs-quarto: true
           sphinxopts: "-j auto --keep-going"
         env:
-          # PYVISTA_BUILDING_GALLERY: 'True'
+          PYVISTA_BUILDING_GALLERY: 'True'
           PYPRIMEMESH_LAUNCH_CONTAINER: 1
           PYPRIMEMESH_SPHINX_BUILD: 1
           PYPRIMEMESH_IMAGE_TAG: ${{ env.DOCKER_IMAGE_TAG }}

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -48,12 +48,12 @@ jobs:
     steps:
       - uses: ansys/actions/check-vulnerabilities@v10.0.3
         with:
-          upload-reports: true
-          hide-log: false
+          # upload-reports: true
+          # hide-log: false
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
           python-package-name: ${{ env.PACKAGE_NAME }}
-          dev-mode: ${{ github.ref != 'refs/heads/main' }}
+          # dev-mode: ${{ github.ref != 'refs/heads/main' }}
 
   style:
     name: Code style

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -126,7 +126,7 @@ jobs:
           needs-quarto: true
           sphinxopts: "-j auto --keep-going"
         env:
-          PYVISTA_BUILDING_GALLERY: 'True'
+          # PYVISTA_BUILDING_GALLERY: 'True'
           PYPRIMEMESH_LAUNCH_CONTAINER: 1
           PYPRIMEMESH_SPHINX_BUILD: 1
           PYPRIMEMESH_IMAGE_TAG: ${{ env.DOCKER_IMAGE_TAG }}

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -102,8 +102,7 @@ jobs:
   docs:
     name: Documentation
     if: github.event.action != 'closed'
-    # runs-on: public-ubuntu-latest-16-cores
-    runs-on: ubuntu-latest
+    runs-on: public-ubuntu-latest-16-cores
     needs: [docs-style]
     steps:
       - name: Login in Github Container registry

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -53,17 +53,17 @@ jobs:
           python-package-name: ${{ env.PACKAGE_NAME }}
           dev-mode: ${{ github.ref != 'refs/heads/main' }}
 
-  # style:
-  #   name: Code style
-  #   if: github.event.action != 'closed'
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: PyAnsys code style checks
-  #       uses: ansys/actions/code-style@v9
-  #       with:
-  #         python-version: ${{ env.MAIN_PYTHON_VERSION }}
-  #         vale-config: "doc/.vale.ini"
-  #         vale-version: "3.4.1"
+  style:
+    name: Code style
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: PyAnsys code style checks
+        uses: ansys/actions/code-style@v9
+        with:
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+          vale-config: "doc/.vale.ini"
+          vale-version: "3.4.1"
 
   docs-style:
     name: Documentation Style Check
@@ -79,7 +79,7 @@ jobs:
     name: Build and Smoke tests
     if: github.event.action != 'closed'
     runs-on: ${{ matrix.os }}
-    # needs: [style]
+    needs: [style]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -48,6 +48,7 @@ jobs:
     steps:
       - uses: ansys/actions/check-vulnerabilities@v10.0.3
         with:
+          upload-reports: true
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
           python-package-name: ${{ env.PACKAGE_NAME }}

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -53,17 +53,17 @@ jobs:
           python-package-name: ${{ env.PACKAGE_NAME }}
           dev-mode: ${{ github.ref != 'refs/heads/main' }}
 
-  style:
-    name: Code style
-    if: github.event.action != 'closed'
-    runs-on: ubuntu-latest
-    steps:
-      - name: PyAnsys code style checks
-        uses: ansys/actions/code-style@v9
-        with:
-          python-version: ${{ env.MAIN_PYTHON_VERSION }}
-          vale-config: "doc/.vale.ini"
-          vale-version: "3.4.1"
+  # style:
+  #   name: Code style
+  #   if: github.event.action != 'closed'
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: PyAnsys code style checks
+  #       uses: ansys/actions/code-style@v9
+  #       with:
+  #         python-version: ${{ env.MAIN_PYTHON_VERSION }}
+  #         vale-config: "doc/.vale.ini"
+  #         vale-version: "3.4.1"
 
   docs-style:
     name: Documentation Style Check
@@ -79,7 +79,7 @@ jobs:
     name: Build and Smoke tests
     if: github.event.action != 'closed'
     runs-on: ${{ matrix.os }}
-    needs: [style]
+    # needs: [style]
     strategy:
       fail-fast: false
       matrix:
@@ -102,7 +102,7 @@ jobs:
   docs:
     name: Documentation
     if: github.event.action != 'closed'
-    runs-on: ubuntu-latest
+    runs-on: public-ubuntu-latest-16-cores
     needs: [docs-style]
     steps:
       - name: Login in Github Container registry
@@ -126,6 +126,7 @@ jobs:
           needs-quarto: true
           sphinxopts: "-j auto --keep-going"
         env:
+          PYVISTA_BUILDING_GALLERY: 'True'
           PYPRIMEMESH_LAUNCH_CONTAINER: 1
           PYPRIMEMESH_SPHINX_BUILD: 1
           PYPRIMEMESH_IMAGE_TAG: ${{ env.DOCKER_IMAGE_TAG }}

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -48,12 +48,10 @@ jobs:
     steps:
       - uses: ansys/actions/check-vulnerabilities@v10.0.3
         with:
-          # upload-reports: true
-          # hide-log: false
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
           python-package-name: ${{ env.PACKAGE_NAME }}
-          # dev-mode: ${{ github.ref != 'refs/heads/main' }}
+          dev-mode: ${{ github.ref != 'refs/heads/main' }}
 
   style:
     name: Code style

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,12 +40,6 @@ repos:
   - id: check-merge-conflict
   - id: debug-statements
 
-# this validates our github workflow files
-- repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.20.0
-  hooks:
-    - id: check-github-workflows
-
 # To be activated after quick dev cycles
 #
 - repo: https://github.com/pycqa/pydocstyle

--- a/doc/changelog.d/1053.documentation.md
+++ b/doc/changelog.d/1053.documentation.md
@@ -1,0 +1,1 @@
+Update ci_cd.yml

--- a/doc/changelog.d/1054.documentation.md
+++ b/doc/changelog.d/1054.documentation.md
@@ -1,0 +1,1 @@
+doc: parallel gallery

--- a/doc/changelog.d/1057.fixed.md
+++ b/doc/changelog.d/1057.fixed.md
@@ -1,0 +1,1 @@
+fix: unique container name

--- a/doc/changelog.d/1058.documentation.md
+++ b/doc/changelog.d/1058.documentation.md
@@ -1,0 +1,1 @@
+Doc/parallel gallery

--- a/doc/changelog.d/1059.added.md
+++ b/doc/changelog.d/1059.added.md
@@ -1,1 +1,0 @@
-feature: Enable parallel execution of example scripts before Sphinx build

--- a/doc/changelog.d/1059.added.md
+++ b/doc/changelog.d/1059.added.md
@@ -1,0 +1,1 @@
+feature: Enable parallel execution of example scripts before Sphinx build

--- a/doc/changelog.d/1059.maintenance.md
+++ b/doc/changelog.d/1059.maintenance.md
@@ -1,0 +1,1 @@
+Feature: enable parallel execution of example scripts before sphinx build

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -10,7 +10,6 @@ os.environ["SPHINX_GALLERY_CONF_FORCE_FRESH"] = "0"
 
 import ansys.tools.visualization_interface as viz_interface
 import pyvista
-import sphinx_gallery.gen_gallery as gen_gallery
 from ansys_sphinx_theme import ansys_favicon, get_version_match, pyansys_logo_black
 from joblib import Parallel, delayed
 from pyvista.plotting.utilities.sphinx_gallery import DynamicScraper

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -216,7 +216,11 @@ def run_all_examples_in_parallel():
     All found scripts are executed in parallel using all available CPU cores.
     """
     example_scripts = glob.glob(
-        os.path.join(os.path.dirname(__file__), "../../examples/**/*.py"), recursive=True,
+        os.path.join(
+            os.path.dirname(__file__),
+            "../../examples/**/*.py",
+        ),
+        recursive=True,
     )
     # Exclude any scripts in 'examples/other'
     example_scripts = [f for f in example_scripts if "examples/other" not in f.replace("\\", "/")]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ tests = [
 doc = [
   "ansys-sphinx-theme[autoapi]==1.5.2",
   "ansys-tools-visualization-interface==0.9.2",
+  "joblib==1.5.1",
   "jupyter-sphinx==0.5.3",
   "numpydoc==1.8.0",
   "sphinx==8.2.3",

--- a/src/ansys/meshing/prime/internals/utils.py
+++ b/src/ansys/meshing/prime/internals/utils.py
@@ -24,6 +24,7 @@ import logging
 import os
 import shutil
 import subprocess
+import uuid
 from contextlib import contextmanager
 from typing import List, Optional
 
@@ -31,7 +32,6 @@ import ansys.meshing.prime.internals.config as config
 import ansys.meshing.prime.internals.defaults as defaults
 
 _LOCAL_PORTS = []
-_PRIME_CONTAINER_COUNT = 0
 
 
 def make_unique_container_name(name: str):
@@ -47,9 +47,7 @@ def make_unique_container_name(name: str):
     str
         Unique name with a numeric integer added as suffix.
     """
-    global _PRIME_CONTAINER_COUNT
-    _PRIME_CONTAINER_COUNT = _PRIME_CONTAINER_COUNT + 1
-    return f'{name}-{_PRIME_CONTAINER_COUNT}'
+    return f'{name}-' + str(uuid.uuid4())
 
 
 def to_camel_case(snake_str):


### PR DESCRIPTION
## Description
This PR adds a mechanism to run all example scripts in parallel before the Sphinx documentation build, excluding scripts in [other](vscode-file://vscode-app/c:/Users/mwalters/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) and files containing flycheck. This speeds up gallery output generation and works around the lack of native per-example parallelism in Sphinx Gallery. Docstrings have also been improved for maintainability.

## Issue also fixed in this PR
#1056 

