### PR TITLE
fix: Docs not being deployed to gh-pages

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -251,7 +251,7 @@ jobs:
 
   upload_docs_release:
     name: Upload release documentation
-    if: (github.event_name == 'push' || github.event_name == 'merge_group') && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev')
+    if: contains('["push","merge_group"]', github.event_name) && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev')
     runs-on: ubuntu-latest
     needs: [release]
     steps:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -251,7 +251,7 @@ jobs:
 
   upload_docs_release:
     name: Upload release documentation
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev')
+    if: github.event_name == ('push' || 'merge_group') && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev')
     runs-on: ubuntu-latest
     needs: [release]
     steps:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -251,7 +251,7 @@ jobs:
 
   upload_docs_release:
     name: Upload release documentation
-    if: github.event_name == ('push' || 'merge_group') && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev')
+    if: (github.event_name == 'push' || github.event_name == 'merge_group') && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev')
     runs-on: ubuntu-latest
     needs: [release]
     steps:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -237,7 +237,7 @@ jobs:
 
   upload_dev_docs:
     name: Upload dev documentation
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     needs: [package]
     steps:

--- a/doc/changelog.d/1281.fixed.md
+++ b/doc/changelog.d/1281.fixed.md
@@ -1,0 +1,1 @@
+Fix: Docs not being deployed to gh-pages


### PR DESCRIPTION
## Description
Right now docs are not being deployed because the action is looking only for "push" event name. However, since we are using the merge queue, we should be looking for "merge_queue".

## Issue linked
**Please mention the issue number or describe the problem this pull request addresses.**

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate unit tests.
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved to the PR if any.
- [x] I have assigned this PR to myself.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: wrap with feature edges``)
