### PR TITLE
doc/fix enum inheritance

### DIFF
--- a/doc/changelog.d/1325.documentation.md
+++ b/doc/changelog.d/1325.documentation.md
@@ -1,0 +1,1 @@
+Doc/fix enum inheritance

--- a/doc/source/_templates/autosummary/class.rst
+++ b/doc/source/_templates/autosummary/class.rst
@@ -7,13 +7,14 @@
 .. autoclass:: {{ objname }}
 
    {% block methods %}
-   {% if methods %}
+   {% set visible_methods = methods | reject('equalto', '__init__') | list %}
+   {% if visible_methods %}
    .. rubric:: {{ _('Methods') }}
 
    .. autosummary::
       :toctree:
-   {% for item in methods %}
-      {% if item != '__init__' %}{{ name }}.{{ item }}{% endif %}
+   {% for item in visible_methods %}
+      {{ name }}.{{ item }}
    {%- endfor %}
    {% endif %}
    {% endblock %}

--- a/doc/source/_templates/autosummary/module.rst
+++ b/doc/source/_templates/autosummary/module.rst
@@ -2,7 +2,7 @@
 
 {{ fullname | escape | underline}}
 
-.. currentmodule:: {{ fullname }}
+.. module:: {{ fullname }}
 
 {% block attributes %}
 {% if attributes %}

--- a/doc/source/api/index.rst
+++ b/doc/source/api/index.rst
@@ -6,10 +6,24 @@ API reference
 
 This section gives an overview of all API classes, methods, and parameters present in PyPrimeMesh.
 
-.. autosummary::
-   :toctree: _autosummary
-   
-   ansys.meshing.prime
-   ansys.meshing.prime.examples
-   ansys.meshing.prime.graphics
-   ansys.meshing.prime.lucid
+.. The autosummary directive below is intentionally placed inside a reST comment.
+   It is not rendered in the page body, but ``autosummary_generate`` still scans
+   it and generates the stub pages under ``_autosummary/``. The visible toctree
+   that follows presents the modules as a navigation list that mirrors the
+   section navigation, instead of an autosummary summary table.
+
+   .. autosummary::
+      :toctree: _autosummary
+
+      ansys.meshing.prime
+      ansys.meshing.prime.examples
+      ansys.meshing.prime.graphics
+      ansys.meshing.prime.lucid
+
+.. toctree::
+   :maxdepth: 1
+
+   ansys.meshing.prime <_autosummary/ansys.meshing.prime>
+   ansys.meshing.prime.examples <_autosummary/ansys.meshing.prime.examples>
+   ansys.meshing.prime.graphics <_autosummary/ansys.meshing.prime.graphics>
+   ansys.meshing.prime.lucid <_autosummary/ansys.meshing.prime.lucid>

--- a/doc/source/api/index.rst
+++ b/doc/source/api/index.rst
@@ -6,24 +6,10 @@ API reference
 
 This section gives an overview of all API classes, methods, and parameters present in PyPrimeMesh.
 
-.. The autosummary directive below is intentionally placed inside a reST comment.
-   It is not rendered in the page body, but ``autosummary_generate`` still scans
-   it and generates the stub pages under ``_autosummary/``. The visible toctree
-   that follows presents the modules as a navigation list that mirrors the
-   section navigation, instead of an autosummary summary table.
+.. autosummary::
+   :toctree: _autosummary
 
-   .. autosummary::
-      :toctree: _autosummary
-
-      ansys.meshing.prime
-      ansys.meshing.prime.examples
-      ansys.meshing.prime.graphics
-      ansys.meshing.prime.lucid
-
-.. toctree::
-   :maxdepth: 1
-
-   ansys.meshing.prime <_autosummary/ansys.meshing.prime>
-   ansys.meshing.prime.examples <_autosummary/ansys.meshing.prime.examples>
-   ansys.meshing.prime.graphics <_autosummary/ansys.meshing.prime.graphics>
-   ansys.meshing.prime.lucid <_autosummary/ansys.meshing.prime.lucid>
+   ansys.meshing.prime
+   ansys.meshing.prime.examples
+   ansys.meshing.prime.graphics
+   ansys.meshing.prime.lucid

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -234,6 +234,43 @@ def run_all_examples_in_parallel():
     Parallel(n_jobs=-1)(delayed(run_example)(script) for script in example_scripts)
 
 
+def skip_int_enum_members(app, what, name, obj, skip, options):
+    """Hide ``int``-inherited members that leak into ``IntEnum`` API pages.
+
+    The enums in ``ansys.meshing.prime`` subclass :class:`enum.IntEnum`, which
+    subclasses :class:`int`. As of recent Sphinx versions, autosummary surfaces
+    the inherited ``int`` members (``conjugate``, ``bit_length``, ``bit_count``,
+    ``to_bytes``, ``from_bytes``, ``as_integer_ratio``, ``real``, ``imag``,
+    ``numerator``, ``denominator``, ``is_integer``) in the API reference. This
+    handler drops them while preserving the meaningful ``name``/``value`` enum
+    members.
+
+    Parameters
+    ----------
+    app : sphinx.application.Sphinx
+        The Sphinx application object.
+    what : str
+        The type of the object which the docstring belongs to.
+    name : str
+        The name of the member being considered.
+    obj : Any
+        The member object itself.
+    skip : bool
+        Whether Sphinx would skip this member by default.
+    options : Any
+        The options given to the directive.
+
+    Returns
+    -------
+    bool or None
+        ``True`` to force skipping the member, otherwise ``None`` to defer to
+        the default behavior.
+    """
+    if name in vars(int) and name not in vars(object):
+        return True
+    return None
+
+
 def setup(app):
     """Sphinx setup function to run all example scripts in parallel before building the docs.
 
@@ -243,6 +280,7 @@ def setup(app):
         The Sphinx application object.
     """
     app.connect("builder-inited", lambda app: run_all_examples_in_parallel())
+    app.connect("autodoc-skip-member", skip_int_enum_members)
 
 
 # Suppress warnings

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -88,7 +88,6 @@ extensions = [
     "sphinx.ext.coverage",
     "sphinx.ext.doctest",
     "sphinx.ext.extlinks",
-    "sphinx.ext.napoleon",
     "sphinx_autodoc_typehints",
     "sphinxemoji.sphinxemoji",
     "sphinx_design",

--- a/src/ansys/meshing/prime/examples/__init__.py
+++ b/src/ansys/meshing/prime/examples/__init__.py
@@ -20,6 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+"""Download example geometry and mesh files for use with PyPrimeMesh."""
+
 from .examples import (
     download_block_model_fmd,
     download_block_model_pmdat,

--- a/src/ansys/meshing/prime/graphics/__init__.py
+++ b/src/ansys/meshing/prime/graphics/__init__.py
@@ -20,4 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+"""Graphics and plotting utilities for visualizing PyPrimeMesh models."""
+
 from ansys.meshing.prime.graphics.plotter import Graphics, PrimePlotter


### PR DESCRIPTION
Fixing the config for doc build so inheritance from int for intEnums does not populate API reference docs and they are displayed correctly.

[Original](https://prime.docs.pyansys.com/version/stable/api/_autosummary/ansys.meshing.prime.CadFaceter.html) vs [Fix](https://prime.docs.pyansys.com/pull/1325/api/_autosummary/ansys.meshing.prime.CadFaceter.html)

