### PR TITLE
fix/quadratic display

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -22,7 +22,7 @@ env:
   PACKAGE_NAME: 'ansys-meshing-prime'
   PACKAGE_NAMESPACE: 'ansys.meshing.prime'
   DOCUMENTATION_CNAME: 'prime.docs.pyansys.com'
-  RESET_IMAGE_CACHE: 0
+  RESET_IMAGE_CACHE: 1
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/doc/changelog.d/1327.fixed.md
+++ b/doc/changelog.d/1327.fixed.md
@@ -1,0 +1,1 @@
+Fix/quadratic display

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,6 @@ tests = [
   "pytest-xvfb==3.1.1",
   "ansys-geometry-core>=0.7.6,<1",
   "pyvista[trame]==0.48.4",
-  # 3.13.3 ships without its bundled vue2-www/vue3-www assets, so the trame
-  # server fails to start. Remove once a fixed release is available.
-  "trame-client==3.13.2",
 ]
 doc = [
   "ansys-sphinx-theme[autoapi]==1.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,9 +62,6 @@ doc = [
   "sphinx-jinja==2.0.2",
   "sphinx-notfound-page==1.1.0",
   "sphinxemoji==0.3.2",
-  # 3.13.3 ships without its bundled vue2-www/vue3-www assets, so the trame
-  # server fails to start. Remove once a fixed release is available.
-  "trame-client==3.13.2",
 ]
 all = [
   "ansys-tools-visualization-interface>=0.2.6,<1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ tests = [
   "pytest-xvfb==3.1.1",
   "ansys-geometry-core>=0.7.6,<1",
   "pyvista[trame]==0.48.4",
+  # 3.13.3 ships without its bundled vue2-www/vue3-www assets, so the trame
+  # server fails to start. Remove once a fixed release is available.
+  "trame-client==3.13.2",
 ]
 doc = [
   "ansys-sphinx-theme[autoapi]==1.9.0",
@@ -61,7 +64,10 @@ doc = [
   "sphinx-gallery==0.21.0",
   "sphinx-jinja==2.0.2",
   "sphinx-notfound-page==1.1.0",
-  "sphinxemoji==0.3.2"
+  "sphinxemoji==0.3.2",
+  # 3.13.3 ships without its bundled vue2-www/vue3-www assets, so the trame
+  # server fails to start. Remove once a fixed release is available.
+  "trame-client==3.13.2",
 ]
 all = [
   "ansys-tools-visualization-interface>=0.2.6,<1",

--- a/src/ansys/meshing/prime/core/mesh.py
+++ b/src/ansys/meshing/prime/core/mesh.py
@@ -330,16 +330,6 @@ class Mesh(MeshInfo):
         -------
         MeshObjectPlot, DisplayMeshInfo
             Mesh to be plotted and information of the mesh to display.
-
-        Notes
-        -----
-        Quadratic and polygonal facets reach the renderer as polygons of more than
-        four nodes. VTK tessellates such a polygon at draw time by fanning it from
-        its first node, which on a curved facet swallows the element outlines behind
-        the shaded surface when viewed head on, and leaves bright slivers along them
-        at oblique angles. Those zonelets are therefore given an explicit
-        triangulation to shade, together with the outlines of the original polygons
-        for the plotter to draw as independent line geometry.
         """
         part = self._model.get_part(part_id)
 

--- a/src/ansys/meshing/prime/core/mesh.py
+++ b/src/ansys/meshing/prime/core/mesh.py
@@ -94,6 +94,14 @@ class DisplayMeshInfo:
         Name of the zone.
     display_mesh_type : DisplayMeshType, default: FACEZONELET
         Type of mesh to display.
+    render_mesh : pv.PolyData, default: None
+        Triangulated geometry to shade in place of the facets themselves. This is
+        set only for zonelets that VTK cannot tessellate acceptably on its own. For
+        more information, see :func:`Mesh.get_face_polydata`.
+    element_edges : pv.PolyData, default: None
+        Element outlines to draw as separate line geometry. This is set only for
+        zonelets whose outlines cannot be drawn by the face actor itself. For more
+        information, see :func:`Mesh.get_face_polydata`.
     """
 
     def __init__(
@@ -105,6 +113,8 @@ class DisplayMeshInfo:
         zone_name=None,
         display_mesh_type=DisplayMeshType.FACEZONELET,
         has_mesh=False,
+        render_mesh=None,
+        element_edges=None,
     ) -> None:
         """Initialize display mesh information."""
         self.id = id
@@ -114,6 +124,8 @@ class DisplayMeshInfo:
         self.zone_name = zone_name
         self.display_mesh_type = display_mesh_type
         self.has_mesh = has_mesh
+        self.render_mesh = render_mesh
+        self.element_edges = element_edges
 
 
 def compute_distance(point1, point2) -> float:
@@ -318,6 +330,16 @@ class Mesh(MeshInfo):
         -------
         MeshObjectPlot, DisplayMeshInfo
             Mesh to be plotted and information of the mesh to display.
+
+        Notes
+        -----
+        Quadratic and polygonal facets reach the renderer as polygons of more than
+        four nodes. VTK tessellates such a polygon at draw time by fanning it from
+        its first node, which on a curved facet swallows the element outlines behind
+        the shaded surface when viewed head on, and leaves bright slivers along them
+        at oblique angles. Those zonelets are therefore given an explicit
+        triangulation to shade, together with the outlines of the original polygons
+        for the plotter to draw as independent line geometry.
         """
         part = self._model.get_part(part_id)
 
@@ -334,7 +356,11 @@ class Mesh(MeshInfo):
         else:
             display_mesh_type = DisplayMeshType.FACEZONELET
             id = face_facet_res.face_zonelet_ids[index]
-
+        render_mesh = None
+        element_edges = None
+        if has_mesh and surf.n_cells > 0 and surf.GetPolys().GetMaxCellSize() > 4:
+            render_mesh = surf.triangulate(progress_bar=False)
+            element_edges = surf.extract_all_edges(progress_bar=False)
         if surf.n_points > 0:
             return MeshObjectPlot(part, surf), DisplayMeshInfo(
                 id=id,
@@ -344,6 +370,8 @@ class Mesh(MeshInfo):
                 part_name=part.name,
                 zone_name=face_facet_res.face_zone_names[index],
                 has_mesh=has_mesh,
+                render_mesh=render_mesh,
+                element_edges=element_edges,
             )
 
     def get_edge_polydata(

--- a/src/ansys/meshing/prime/core/mesh.py
+++ b/src/ansys/meshing/prime/core/mesh.py
@@ -396,24 +396,27 @@ class Mesh(MeshInfo):
         part = self._model.get_part(part_id)
         vertices, faces = self._get_vertices_and_surf_edges(edge_facet_res, index)
         edge = pv.PolyData()
-        n_edges = edge_facet_res.num_edges_per_edge_zonelet[index]
         edge.points = vertices
-        cells = np.full((n_edges, 3), 2, dtype=np.int_)
-        i = 0
+        segments = []
         j = 0
         while j < len(faces):
             nnodes = faces[j]
-            j += 1
-            cells[i, 1] = faces[j]
-            if nnodes == 2:
-                cells[i, 2] = faces[j + 1]
-            elif nnodes == 3:
-                cells[i, 2] = faces[j + 2]
-            j += nnodes
-            i += 1
+            nodes = faces[j + 1 : j + 1 + nnodes]
+            if nnodes == 3:
+                # a quadratic edge arrives as (start, mid, end); drawing it as a
+                # single start to end segment cuts across the curve the mid-side
+                # node describes, so draw both halves instead
+                segments.append((nodes[0], nodes[1]))
+                segments.append((nodes[1], nodes[2]))
+            else:
+                segments.append((nodes[0], nodes[1]))
+            j += 1 + nnodes
+        cells = np.full((len(segments), 3), 2, dtype=np.int_)
+        if segments:
+            cells[:, 1:] = segments
         edge.lines = cells
         ecolor = np.array(self.get_edge_color(edge_facet_res, index))
-        colors = np.tile(ecolor, (n_edges, 1))
+        colors = np.tile(ecolor, (len(segments), 1))
         edge["colors"] = colors
         if edge.n_points > 0:
             return MeshObjectPlot(part, edge)

--- a/src/ansys/meshing/prime/graphics/plotter.py
+++ b/src/ansys/meshing/prime/graphics/plotter.py
@@ -26,6 +26,7 @@ import warnings
 from typing import Any, Dict, List, Optional
 
 import numpy as np
+import pyvista as pv
 from ansys.tools.visualization_interface import Plotter
 from ansys.tools.visualization_interface.backends.pyvista import PyVistaBackend
 
@@ -62,6 +63,13 @@ class ColorByType(enum.IntEnum):
     PART = 2
 
 
+# Depth-buffer offset applied to a face actor whose element outlines are drawn as a
+# separate line actor, so that the shaded surface cannot z-fight with those lines.
+# The first value scales with the depth slope of the polygon, the second is constant.
+POLYGON_OFFSET_FACTOR = 1.0
+POLYGON_OFFSET_UNITS = 1.0
+
+
 class PrimePlotter(Plotter):
     """Create a plotter for PyPrimeMesh models.
 
@@ -85,6 +93,8 @@ class PrimePlotter(Plotter):
 
         # info of the actor to pass to picked info widget
         self._info_actor_map = {}
+        # element outlines drawn separately, keyed by the face actor they belong to
+        self._element_edge_actors = {}
         self._backend.add_widget(ToggleEdges(self))
         self._backend.add_widget(ColorByTypeWidget(self))
         self._backend.add_widget(HidePicked(self))
@@ -111,6 +121,17 @@ class PrimePlotter(Plotter):
             Information actor map.
         """
         self._info_actor_map = value
+
+    @property
+    def element_edge_actors(self) -> Dict:
+        """Get the element outlines that are drawn as separate line geometry.
+
+        Returns
+        -------
+        Dict
+            Actor holding the outlines of each face actor that has them.
+        """
+        return self._element_edge_actors
 
     @property
     def scene(self):
@@ -237,12 +258,19 @@ class PrimePlotter(Plotter):
                     # but we need the actor for the picked info widget
                     colors = self.get_scalar_colors(face_mesh_info)
                     has_mesh = face_mesh_info.has_mesh
+                    element_edges = face_mesh_info.element_edges
+                    render_mesh = face_mesh_info.render_mesh
                     actor = self._backend.pv_interface.scene.add_mesh(
-                        face_mesh_part.mesh, show_edges=has_mesh, color=colors, pickable=True
+                        face_mesh_part.mesh if render_mesh is None else render_mesh,
+                        show_edges=has_mesh and element_edges is None,
+                        color=colors,
+                        pickable=True,
                     )
                     face_mesh_part.actor = actor
                     self._backend.pv_interface._object_to_actors_map[actor] = face_mesh_part
                     self._info_actor_map[actor] = face_mesh_info
+                    if element_edges is not None:
+                        self._add_element_edges(actor, element_edges)
 
             if "edges" in part_polydata.keys():
                 for edge_mesh_part in part_polydata["edges"]:
@@ -281,6 +309,28 @@ class PrimePlotter(Plotter):
                     )
                     spline_mesh_part.actor = actor
                     self._backend._object_to_actors_map[actor] = spline_mesh_part
+
+    def _add_element_edges(self, face_actor, element_edges) -> None:
+        """Draw element outlines that the face actor cannot draw itself.
+
+        Parameters
+        ----------
+        face_actor : pyvista.Actor
+            Actor of the shaded faces the outlines belong to.
+        element_edges : pyvista.PolyData
+            Element outlines to draw.
+        """
+        mapper = face_actor.GetMapper()
+        mapper.SetResolveCoincidentTopologyToPolygonOffset()
+        mapper.SetRelativeCoincidentTopologyPolygonOffsetParameters(
+            POLYGON_OFFSET_FACTOR, POLYGON_OFFSET_UNITS
+        )
+        self._element_edge_actors[face_actor] = self._backend.pv_interface.scene.add_mesh(
+            element_edges,
+            color=pv.global_theme.edge_color,
+            line_width=1,
+            pickable=False,
+        )
 
     def add_scope(self, model: Model, scope: prime.ScopeDefinition, update: bool = False) -> None:
         """Add a scope to the plotter.

--- a/src/ansys/meshing/prime/graphics/widgets/hide_picked.py
+++ b/src/ansys/meshing/prime/graphics/widgets/hide_picked.py
@@ -48,6 +48,7 @@ class HidePicked(PlotterWidget):
         self.prime_plotter = prime_plotter
         self._picked_dict = self.prime_plotter._backend._custom_picker._picked_dict
         self._object_actors_map = self.prime_plotter._backend._object_to_actors_map
+        self._element_edge_actors = self.prime_plotter._element_edge_actors
         self._button = self.prime_plotter._backend._pl.scene.add_checkbox_button_widget(
             self.callback,
             position=(5, 660),
@@ -58,12 +59,21 @@ class HidePicked(PlotterWidget):
         )
         self._removed_actors = []
 
+    def _actors_of(self, meshobject) -> list:
+        """Get every actor that draws a mesh object, outlines included."""
+        actors = [meshobject.actor]
+        edge_actor = self._element_edge_actors.get(meshobject.actor)
+        if edge_actor is not None:
+            actors.append(edge_actor)
+        return actors
+
     def callback(self, state: bool) -> None:
         """Define callback function for the button widget."""
         if state:
             for meshobject in list(self._picked_dict.values()):
-                self.prime_plotter._backend.pv_interface.scene.remove_actor(meshobject.actor)
-                self._removed_actors.append(meshobject.actor)
+                for actor in self._actors_of(meshobject):
+                    self.prime_plotter._backend.pv_interface.scene.remove_actor(actor)
+                    self._removed_actors.append(actor)
         else:
             for actor in self._removed_actors:
                 self.prime_plotter._backend._pl.scene.add_actor(actor)

--- a/src/ansys/meshing/prime/graphics/widgets/toggle_edges.py
+++ b/src/ansys/meshing/prime/graphics/widgets/toggle_edges.py
@@ -53,6 +53,7 @@ class ToggleEdges(PlotterWidget):
             color_on="white",
         )
         self._info_actor_map = self.prime_plotter._info_actor_map
+        self._element_edge_actors = self.prime_plotter._element_edge_actors
 
     def callback(self, state: bool) -> None:
         """Toggle the edges of the mesh objects.
@@ -65,6 +66,10 @@ class ToggleEdges(PlotterWidget):
         for key, actor in self.prime_plotter._backend._pl.scene.actors.items():
             if actor in self._info_actor_map and self._info_actor_map[actor].has_mesh:
                 actor.prop.show_edges = not state
+        # element outlines drawn as separate line geometry are hidden as a whole,
+        # since they are lines rather than the edges of a shaded actor
+        for actor in self._element_edge_actors.values():
+            actor.visibility = not state
 
     def update(self) -> None:
         """Define the configuration and representation of the button widget button."""

--- a/tests/graphics/test_graphics.py
+++ b/tests/graphics/test_graphics.py
@@ -199,8 +199,6 @@ def test_quadratic_tet_plotter(get_remote_client, get_examples, verify_image_cac
     display.show()
 
 
-
-
 def test_compute_distance():
     point1 = [1, 1, 3]
     point2 = [1, 1, 1]

--- a/tests/graphics/test_graphics.py
+++ b/tests/graphics/test_graphics.py
@@ -55,6 +55,66 @@ def test_plotter(get_remote_client, get_examples, verify_image_cache):
     display.show()
 
 
+
+def _check_element_outlines(model_pd):
+    """Check outlines are held for the zonelets the face actor cannot draw itself.
+
+    Returns the number of zonelets that hold outlines.
+    """
+    count = 0
+    for part_pd in model_pd.values():
+        for mesh_object, info in part_pd["faces"]:
+            higher_order = mesh_object.mesh.GetPolys().GetMaxCellSize() > 4
+            expected = info.has_mesh and higher_order
+            assert (info.element_edges is not None) == expected
+            assert (info.render_mesh is not None) == expected
+            if expected:
+                assert info.element_edges.n_cells > 0
+                # shaded with an explicit triangulation, outlined with the real facets
+                assert info.render_mesh.GetPolys().GetMaxCellSize() == 3
+                assert info.render_mesh.n_cells > mesh_object.mesh.n_cells
+                count += 1
+    return count
+
+
+def _mesh_elbow(model, mixing_elbow, quadratic):
+    """Volume mesh the mixing elbow in an empty model and return its polydata."""
+    model.delete_parts([part.id for part in model.parts])
+    mesh_util = prime.lucid.Mesh(model=model)
+    mesh_util.read(mixing_elbow)
+    mesh_util.surface_mesh(min_size=5, max_size=20)
+    mesh_util.volume_mesh(quadratic=quadratic, volume_fill_type=prime.VolumeFillType.TET)
+    return model.as_polydata(update=True)
+
+
+def test_quadratic_element_outlines(get_remote_client, get_examples):
+    """Quadratic facets get their outlines drawn as separate line geometry."""
+    mixing_elbow = get_examples["elbow_lucid"]
+    model = get_remote_client.model
+
+    # linear facets are drawn by the face actor itself, as they always have been
+    linear_pd = _mesh_elbow(model, mixing_elbow, quadratic=False)
+    assert _check_element_outlines(linear_pd) == 0
+
+    linear_display = PrimePlotter()
+    linear_display.add_model_pd(linear_pd)
+    assert linear_display.element_edge_actors == {}
+
+    quadratic_pd = _mesh_elbow(model, mixing_elbow, quadratic=True)
+    expected = _check_element_outlines(quadratic_pd)
+    assert expected > 0
+
+    display = PrimePlotter()
+    display.add_model_pd(quadratic_pd)
+    outlines = display.element_edge_actors
+    assert len(outlines) == expected
+    assert all(actor.visibility for actor in outlines.values())
+    # every outline is keyed by the face actor it belongs to, so that hiding a
+    # zonelet hides its outlines too
+    face_actors = [actor for actor in display.info_actor_map if actor in outlines]
+    assert len(face_actors) == expected
+
+
 def test_compute_distance():
     point1 = [1, 1, 3]
     point2 = [1, 1, 1]

--- a/tests/graphics/test_graphics.py
+++ b/tests/graphics/test_graphics.py
@@ -120,6 +120,24 @@ def test_quadratic_element_outlines(get_remote_client, get_examples):
         display.scene.close()
 
 
+def test_quadratic_tet_plotter(get_remote_client, get_examples, verify_image_cache):
+    """Visual regression for quadratic tet outlines on a curved model.
+
+    Uses an oblique camera so mid-side node edges on the bend are visible in the
+    cached screenshot (downloadable from the CI artifact).
+    """
+    mixing_elbow = get_examples["elbow_lucid"]
+    model = get_remote_client.model
+    _mesh_elbow(model, mixing_elbow, quadratic=True)
+
+    display = PrimePlotter()
+    display.plot(model)
+    display.scene.view_isometric()
+    display.scene.camera.elevation = 25
+    display.scene.camera.azimuth = 35
+    display.show()
+
+
 def test_compute_distance():
     point1 = [1, 1, 3]
     point2 = [1, 1, 1]

--- a/tests/graphics/test_graphics.py
+++ b/tests/graphics/test_graphics.py
@@ -152,7 +152,7 @@ def test_quadratic_edge_zonelets_follow_mid_nodes(get_remote_client, get_example
     it, and the line cuts the chord of the curve the node was projected onto.
     """
     model = get_remote_client.model
-    _curved_quadratic_elbow(model, get_examples["elbow_fmd"])
+    _curved_quadratic_elbow(model, get_examples["elbow_lucid"])
     model_pd = model.as_polydata(update=True)
 
     checked = 0
@@ -176,7 +176,7 @@ def test_quadratic_tet_plotter(get_remote_client, get_examples, verify_image_cac
     and the mid-side subdivision within each facet are most obvious.
     """
     model = get_remote_client.model
-    _curved_quadratic_elbow(model, get_examples["elbow_fmd"])
+    _curved_quadratic_elbow(model, get_examples["elbow_lucid"])
 
     display = PrimePlotter()
     # update, or the polydata another test already cached for this model is reused

--- a/tests/graphics/test_graphics.py
+++ b/tests/graphics/test_graphics.py
@@ -96,22 +96,28 @@ def test_quadratic_element_outlines(get_remote_client, get_examples):
     assert _check_element_outlines(linear_pd) == 0
 
     linear_display = PrimePlotter()
-    linear_display.add_model_pd(linear_pd)
-    assert linear_display.element_edge_actors == {}
+    try:
+        linear_display.add_model_pd(linear_pd)
+        assert linear_display.element_edge_actors == {}
+    finally:
+        linear_display.scene.close()
 
     quadratic_pd = _mesh_elbow(model, mixing_elbow, quadratic=True)
     expected = _check_element_outlines(quadratic_pd)
     assert expected > 0
 
     display = PrimePlotter()
-    display.add_model_pd(quadratic_pd)
-    outlines = display.element_edge_actors
-    assert len(outlines) == expected
-    assert all(actor.visibility for actor in outlines.values())
-    # every outline is keyed by the face actor it belongs to, so that hiding a
-    # zonelet hides its outlines too
-    face_actors = [actor for actor in display.info_actor_map if actor in outlines]
-    assert len(face_actors) == expected
+    try:
+        display.add_model_pd(quadratic_pd)
+        outlines = display.element_edge_actors
+        assert len(outlines) == expected
+        assert all(actor.visibility for actor in outlines.values())
+        # every outline is keyed by the face actor it belongs to, so that hiding a
+        # zonelet hides its outlines too
+        face_actors = [actor for actor in display.info_actor_map if actor in outlines]
+        assert len(face_actors) == expected
+    finally:
+        display.scene.close()
 
 
 def test_compute_distance():

--- a/tests/graphics/test_graphics.py
+++ b/tests/graphics/test_graphics.py
@@ -23,6 +23,7 @@
 """Module for testing plotter related functions."""
 from pathlib import Path
 
+import numpy as np
 import pyvista as pv
 
 import ansys.meshing.prime as prime
@@ -51,7 +52,7 @@ def test_plotter(get_remote_client, get_examples, verify_image_cache):
     )
 
     display = PrimePlotter()
-    display.plot(model)
+    display.plot(model, update=True)
     display.show()
 
 
@@ -120,22 +121,84 @@ def test_quadratic_element_outlines(get_remote_client, get_examples):
         display.scene.close()
 
 
+def _curved_quadratic_elbow(model, elbow_fmd):
+    """Coarse quadratic tet mesh whose mid-side nodes follow the CAD surface.
+
+    Meshing the faceted PMDAT leaves mid-side nodes on straight edges, so the
+    result is indistinguishable from a linear mesh. Reading the CAD and
+    projecting onto it is what actually bulges the elements out.
+    """
+    if model.parts:
+        model.delete_parts([part.id for part in model.parts])
+    mesh_util = prime.lucid.Mesh(model=model)
+    mesh_util.read(file_name=elbow_fmd)
+    # coarse enough that a single element spans a visible amount of curvature
+    mesh_util.surface_mesh(min_size=25, max_size=60)
+    mesh_util.volume_mesh(quadratic=True, volume_fill_type=prime.VolumeFillType.TET)
+    part = model.parts[0]
+    prime.SurfaceUtilities(model).project_topo_faces_on_geometry(
+        part.get_topo_faces(),
+        prime.ProjectOnGeometryParams(
+            model, project_on_facets_if_cadnot_found=True, project_only_mid_nodes=False
+        ),
+    )
+
+
+def test_quadratic_edge_zonelets_follow_mid_nodes(get_remote_client, get_examples):
+    """Edge zonelets are drawn through their mid-side node, not across it.
+
+    A quadratic edge arrives as ``(start, mid, end)``. Drawing it as one segment
+    leaves the mid node sitting in the point array without any line referencing
+    it, and the line cuts the chord of the curve the node was projected onto.
+    """
+    model = get_remote_client.model
+    _curved_quadratic_elbow(model, get_examples["elbow_fmd"])
+    model_pd = model.as_polydata(update=True)
+
+    checked = 0
+    for part_pd in model_pd.values():
+        for edge_mesh_part in part_pd["edges"]:
+            edge = edge_mesh_part.mesh
+            if edge.n_cells == 0:
+                continue
+            lines = edge.lines.reshape(-1, 3)
+            assert (lines[:, 0] == 2).all()
+            referenced = set(lines[:, 1]) | set(lines[:, 2])
+            assert len(referenced) == edge.n_points
+            checked += 1
+    assert checked > 0
+
+
 def test_quadratic_tet_plotter(get_remote_client, get_examples, verify_image_cache):
     """Visual regression for quadratic tet outlines on a curved model.
 
-    Uses an oblique camera so mid-side node edges on the bend are visible in the
-    cached screenshot (downloadable from the CI artifact).
+    Framed at a grazing angle on the pipe wall, where the curved element edges
+    and the mid-side subdivision within each facet are most obvious.
     """
-    mixing_elbow = get_examples["elbow_lucid"]
     model = get_remote_client.model
-    _mesh_elbow(model, mixing_elbow, quadratic=True)
+    _curved_quadratic_elbow(model, get_examples["elbow_fmd"])
 
     display = PrimePlotter()
-    display.plot(model)
-    display.scene.view_isometric()
-    display.scene.camera.elevation = 25
-    display.scene.camera.azimuth = 35
+    # update, or the polydata another test already cached for this model is reused
+    display.plot(model, update=True)
+
+    scene = display.scene
+    bounds = np.array(scene.bounds).reshape(3, 2)
+    span = float((bounds[:, 1] - bounds[:, 0]).max())
+    target = bounds.mean(axis=1) + np.array([-0.10, -0.10, 0.0]) * span
+    azimuth, elevation = np.radians(72), np.radians(12)
+    direction = np.array(
+        [
+            np.cos(elevation) * np.cos(azimuth),
+            np.cos(elevation) * np.sin(azimuth),
+            np.sin(elevation),
+        ]
+    )
+    scene.camera_position = [tuple(target + direction * span * 1.6), tuple(target), (0, 0, 1)]
+    scene.camera.zoom(2.4)
     display.show()
+
+
 
 
 def test_compute_distance():

--- a/tests/graphics/test_graphics.py
+++ b/tests/graphics/test_graphics.py
@@ -55,7 +55,6 @@ def test_plotter(get_remote_client, get_examples, verify_image_cache):
     display.show()
 
 
-
 def _check_element_outlines(model_pd):
     """Check outlines are held for the zonelets the face actor cannot draw itself.
 


### PR DESCRIPTION
- Not a node-order bug; VTK’s draw-time polygon fan is.
- Tri/quad (MaxCellSize <= 4) unchanged.
- Prefer this over #1220 (avoids wrapping PolyData; keeps ToggleEdges/HidePicked working) and #1222 (reversal only “works” by accident).
- test_plotter image cache may need regenerating (POLY facets hit the new path).

fixes #106 