### PR TITLE
fix: refactor plotter

### DIFF
--- a/doc/changelog.d/1333.documentation.md
+++ b/doc/changelog.d/1333.documentation.md
@@ -1,1 +1,1 @@
-Doc: changes to thumbnails for examples
+Fix: refactor plotter

--- a/doc/changelog.d/1333.documentation.md
+++ b/doc/changelog.d/1333.documentation.md
@@ -1,0 +1,1 @@
+Doc: changes to thumbnails for examples

--- a/examples/gallery/01_bracket_scaffold.py
+++ b/examples/gallery/01_bracket_scaffold.py
@@ -53,6 +53,7 @@ Procedure
 """
 
 # sphinx_gallery_tags = ["Structural", "Shell", "Quad", "Connect"]
+# sphinx_gallery_thumbnail_number = 2
 
 ###############################################################################
 # Launch Ansys Prime Server

--- a/examples/gallery/03_lucid_pipe_tee.py
+++ b/examples/gallery/03_lucid_pipe_tee.py
@@ -58,6 +58,7 @@ Procedure
 """
 
 # sphinx_gallery_tags = ["Fluid", "Structural", "Poly", "Tet", "Prism", "Wrap"]
+# sphinx_gallery_thumbnail_number = 2
 
 ###############################################################################
 # Launch Ansys Prime Server

--- a/examples/gallery/04_lucid_toy_car.py
+++ b/examples/gallery/04_lucid_toy_car.py
@@ -57,6 +57,7 @@ Procedure
 """
 
 # sphinx_gallery_tags = ["Fluid", "Aerodynamics", "Tet", "Prism", "Wrap", "Diagnostics"]
+# sphinx_gallery_thumbnail_number = 8
 
 ###############################################################################
 # Launch Ansys Prime Server

--- a/examples/gallery/05_pcb_stacker.py
+++ b/examples/gallery/05_pcb_stacker.py
@@ -51,6 +51,7 @@ Procedure
 """
 
 # sphinx_gallery_tags = ["Structural", "Hex", "Quad", "Semiconductor", "Stacker"]
+# sphinx_gallery_thumbnail_number = 4
 
 ###############################################################################
 # Launch Ansys Prime Server

--- a/examples/gallery/07_saddle_bracket.py
+++ b/examples/gallery/07_saddle_bracket.py
@@ -55,6 +55,7 @@ Procedure
 """
 
 # sphinx_gallery_tags = ["Structural", "Hex", "Prism", "Quad", "Tri", "Thin volume"]
+# sphinx_gallery_thumbnail_number = 4
 
 ###############################################################################
 # Launch Ansys Prime Server

--- a/examples/gallery/09_multi_layer_quad_mesh_pcb.py
+++ b/examples/gallery/09_multi_layer_quad_mesh_pcb.py
@@ -81,6 +81,7 @@ Procedure
 """
 
 # sphinx_gallery_tags = ["Structural", "Hex", "Quad", "Stacker", "Semiconductor", "Sizing"]
+# sphinx_gallery_thumbnail_number = 3
 
 ###############################################################################
 # Import all necessary modules

--- a/examples/gallery/10_wheel_ground_contact_patch.py
+++ b/examples/gallery/10_wheel_ground_contact_patch.py
@@ -163,9 +163,9 @@ print(model)
 
 display = PrimePlotter()
 display.plot(
-   model,
-   scope=prime.ScopeDefinition(model, label_expression="ground, patch*, wheel"),
-   update=True,
+    model,
+    scope=prime.ScopeDefinition(model, label_expression="ground, patch*, wheel"),
+    update=True,
 )
 display.show()
 
@@ -198,9 +198,9 @@ print(model)
 
 display = PrimePlotter()
 display.plot(
-   model,
-   scope=prime.ScopeDefinition(model, label_expression="ground, patch*, wheel"),
-   update=True,
+    model,
+    scope=prime.ScopeDefinition(model, label_expression="ground, patch*, wheel"),
+    update=True,
 )
 display.show()
 

--- a/examples/gallery/10_wheel_ground_contact_patch.py
+++ b/examples/gallery/10_wheel_ground_contact_patch.py
@@ -104,6 +104,7 @@ print(model)
 display = PrimePlotter()
 display.plot(model, scope=prime.ScopeDefinition(model, label_expression="ground wheel"))
 display.show()
+display.clear()
 
 ###############################################################################
 # Convert topo parts to mesh parts
@@ -160,6 +161,7 @@ display.plot(
     update=True,
 )
 display.show()
+display.clear()
 
 #######################
 # Wrap the fluid region
@@ -191,6 +193,7 @@ display.plot(
     update=True,
 )
 display.show()
+display.clear()
 
 ###############################################################################
 # Volume mesh
@@ -213,6 +216,7 @@ display.plot(
     update=True,
 )
 display.show()
+display.clear()
 
 mesh_util.create_zones_from_labels()
 

--- a/examples/gallery/10_wheel_ground_contact_patch.py
+++ b/examples/gallery/10_wheel_ground_contact_patch.py
@@ -65,6 +65,7 @@ Procedure
 """
 
 # sphinx_gallery_tags = ["Fluid", "Aerodynamics", "Poly", "Prism", "Wrap"]
+# sphinx_gallery_thumbnail_number = 4
 
 ###############################################################################
 # Launch Ansys Prime Server

--- a/examples/gallery/10_wheel_ground_contact_patch.py
+++ b/examples/gallery/10_wheel_ground_contact_patch.py
@@ -98,18 +98,15 @@ mesh_util = prime.lucid.Mesh(model)
 wheel_ground_file = prime.examples.download_wheel_ground_fmd()
 
 mesh_util.read(wheel_ground_file)
-
-
-###################
-# Visualize results
-# ~~~~~~~~~~~~~~~~~
-# .. code-block:: python
-#
-#   display = PrimePlotter()
-#   display.plot(model, scope=prime.ScopeDefinition(model, label_expression="ground, wheel"))
-#   display.show()
-#
 print(model)
+
+########################
+# Show imported geometry
+# ~~~~~~~~~~~~~~~~~~~~~~
+
+display = PrimePlotter()
+display.plot(model, scope=prime.ScopeDefinition(model, label_expression="ground, wheel"))
+display.show()
 
 ###############################################################################
 # Convert topo parts to mesh parts
@@ -159,17 +156,18 @@ result = prime.SurfaceUtilities(model).create_contact_patch(
 print(result.error_code)
 print(model)
 
-###################
-# Visualize results
-# =================
-# .. code-block:: python
-#
-#   display = PrimePlotter()
-#   display.plot(
-#          model, scope=prime.ScopeDefinition(model, label_expression="ground, patch*, wheel")
-#   )
-#   display.show()
-#
+####################
+# Show contact patch
+# ==================
+
+display = PrimePlotter()
+display.plot(
+   model,
+   scope=prime.ScopeDefinition(model, label_expression="ground, patch*, wheel"),
+   update=True,
+)
+display.show()
+
 #######################
 # Wrap the fluid region
 # ~~~~~~~~~~~~~~~~~~~~~
@@ -191,20 +189,19 @@ wrap_part = mesh_util.wrap(
     create_intersection_loops=True,
     wrap_size_controls=[size_control],
 )
-
-#########################
-# Open a pyvistaqt window
-# ~~~~~~~~~~~~~~~~~~~~~~~
-# .. code-block:: python
-#
-#     display = PrimePlotter()
-#     display.plot(
-#         model,
-#         scope=prime.ScopeDefinition(model, label_expression="ground, patch*, wheel"), update=True
-#     )
-#     display.show()
-#
 print(model)
+
+###########
+# Show wrap
+# ~~~~~~~~~
+
+display = PrimePlotter()
+display.plot(
+   model,
+   scope=prime.ScopeDefinition(model, label_expression="ground, patch*, wheel"),
+   update=True,
+)
+display.show()
 
 ###############################################################################
 # Volume mesh

--- a/examples/gallery/10_wheel_ground_contact_patch.py
+++ b/examples/gallery/10_wheel_ground_contact_patch.py
@@ -153,6 +153,7 @@ result = prime.SurfaceUtilities(model).create_contact_patch(
 print(result.error_code)
 print(model)
 
+display.clear()
 display.plot(
     model,
     scope=prime.ScopeDefinition(model, label_expression="ground patch* wheel"),
@@ -183,6 +184,7 @@ wrap_part = mesh_util.wrap(
 )
 
 print(model)
+display.clear()
 display.plot(
     model,
     scope=prime.ScopeDefinition(model, label_expression="ground patch* wheel"),
@@ -204,6 +206,7 @@ mesh_util.volume_mesh(
     scope=prime.lucid.VolumeScope(part_expression=wrap_part.name),
 )
 
+display.clear()
 display.plot(
     model,
     scope=prime.ScopeDefinition(model, label_expression="!front !side_right !top"),

--- a/examples/gallery/10_wheel_ground_contact_patch.py
+++ b/examples/gallery/10_wheel_ground_contact_patch.py
@@ -65,7 +65,6 @@ Procedure
 """
 
 # sphinx_gallery_tags = ["Fluid", "Aerodynamics", "Poly", "Prism", "Wrap"]
-# sphinx_gallery_thumbnail_number = 4
 
 ###############################################################################
 # Launch Ansys Prime Server
@@ -99,12 +98,18 @@ mesh_util = prime.lucid.Mesh(model)
 wheel_ground_file = prime.examples.download_wheel_ground_fmd()
 
 mesh_util.read(wheel_ground_file)
-print(model)
 
-display = PrimePlotter()
-display.plot(model, scope=prime.ScopeDefinition(model, label_expression="ground wheel"))
-display.show()
-display.clear()
+
+###################
+# Visualize results
+# ~~~~~~~~~~~~~~~~~
+# .. code-block:: python
+#
+#   display = PrimePlotter()
+#   display.plot(model, scope=prime.ScopeDefinition(model, label_expression="ground, wheel"))
+#   display.show()
+#
+print(model)
 
 ###############################################################################
 # Convert topo parts to mesh parts
@@ -154,15 +159,17 @@ result = prime.SurfaceUtilities(model).create_contact_patch(
 print(result.error_code)
 print(model)
 
-display.clear()
-display.plot(
-    model,
-    scope=prime.ScopeDefinition(model, label_expression="ground patch* wheel"),
-    update=True,
-)
-display.show()
-display.clear()
-
+###################
+# Visualize results
+# =================
+# .. code-block:: python
+#
+#   display = PrimePlotter()
+#   display.plot(
+#          model, scope=prime.ScopeDefinition(model, label_expression="ground, patch*, wheel")
+#   )
+#   display.show()
+#
 #######################
 # Wrap the fluid region
 # ~~~~~~~~~~~~~~~~~~~~~
@@ -185,15 +192,19 @@ wrap_part = mesh_util.wrap(
     wrap_size_controls=[size_control],
 )
 
+#########################
+# Open a pyvistaqt window
+# ~~~~~~~~~~~~~~~~~~~~~~~
+# .. code-block:: python
+#
+#     display = PrimePlotter()
+#     display.plot(
+#         model,
+#         scope=prime.ScopeDefinition(model, label_expression="ground, patch*, wheel"), update=True
+#     )
+#     display.show()
+#
 print(model)
-display.clear()
-display.plot(
-    model,
-    scope=prime.ScopeDefinition(model, label_expression="ground patch* wheel"),
-    update=True,
-)
-display.show()
-display.clear()
 
 ###############################################################################
 # Volume mesh
@@ -209,14 +220,13 @@ mesh_util.volume_mesh(
     scope=prime.lucid.VolumeScope(part_expression=wrap_part.name),
 )
 
-display.clear()
+display = PrimePlotter()
 display.plot(
     model,
     scope=prime.ScopeDefinition(model, label_expression="!front !side_right !top"),
     update=True,
 )
 display.show()
-display.clear()
 
 mesh_util.create_zones_from_labels()
 

--- a/examples/gallery/10_wheel_ground_contact_patch.py
+++ b/examples/gallery/10_wheel_ground_contact_patch.py
@@ -65,6 +65,7 @@ Procedure
 """
 
 # sphinx_gallery_tags = ["Fluid", "Aerodynamics", "Poly", "Prism", "Wrap"]
+# sphinx_gallery_thumbnail_number = 4
 
 ###############################################################################
 # Launch Ansys Prime Server
@@ -98,18 +99,11 @@ mesh_util = prime.lucid.Mesh(model)
 wheel_ground_file = prime.examples.download_wheel_ground_fmd()
 
 mesh_util.read(wheel_ground_file)
-
-
-###################
-# Visualize results
-# ~~~~~~~~~~~~~~~~~
-# .. code-block:: python
-#
-#   display = PrimePlotter()
-#   display.plot(model, scope=prime.ScopeDefinition(model, label_expression="ground, wheel"))
-#   display.show()
-#
 print(model)
+
+display = PrimePlotter()
+display.plot(model, scope=prime.ScopeDefinition(model, label_expression="ground, wheel"))
+display.show()
 
 ###############################################################################
 # Convert topo parts to mesh parts
@@ -159,17 +153,13 @@ result = prime.SurfaceUtilities(model).create_contact_patch(
 print(result.error_code)
 print(model)
 
-###################
-# Visualize results
-# =================
-# .. code-block:: python
-#
-#   display = PrimePlotter()
-#   display.plot(
-#          model, scope=prime.ScopeDefinition(model, label_expression="ground, patch*, wheel")
-#   )
-#   display.show()
-#
+display.plot(
+    model,
+    scope=prime.ScopeDefinition(model, label_expression="ground, patch*, wheel"),
+    update=True,
+)
+display.show()
+
 #######################
 # Wrap the fluid region
 # ~~~~~~~~~~~~~~~~~~~~~
@@ -192,19 +182,13 @@ wrap_part = mesh_util.wrap(
     wrap_size_controls=[size_control],
 )
 
-#########################
-# Open a pyvistaqt window
-# ~~~~~~~~~~~~~~~~~~~~~~~
-# .. code-block:: python
-#
-#     display = PrimePlotter()
-#     display.plot(
-#         model,
-#         scope=prime.ScopeDefinition(model, label_expression="ground, patch*, wheel"), update=True
-#     )
-#     display.show()
-#
 print(model)
+display.plot(
+    model,
+    scope=prime.ScopeDefinition(model, label_expression="ground, patch*, wheel"),
+    update=True,
+)
+display.show()
 
 ###############################################################################
 # Volume mesh
@@ -220,7 +204,6 @@ mesh_util.volume_mesh(
     scope=prime.lucid.VolumeScope(part_expression=wrap_part.name),
 )
 
-display = PrimePlotter()
 display.plot(
     model,
     scope=prime.ScopeDefinition(model, label_expression="!front !side_right !top"),

--- a/examples/gallery/10_wheel_ground_contact_patch.py
+++ b/examples/gallery/10_wheel_ground_contact_patch.py
@@ -102,7 +102,7 @@ mesh_util.read(wheel_ground_file)
 print(model)
 
 display = PrimePlotter()
-display.plot(model, scope=prime.ScopeDefinition(model, label_expression="ground, wheel"))
+display.plot(model, scope=prime.ScopeDefinition(model, label_expression="ground wheel"))
 display.show()
 
 ###############################################################################
@@ -155,7 +155,7 @@ print(model)
 
 display.plot(
     model,
-    scope=prime.ScopeDefinition(model, label_expression="ground, patch*, wheel"),
+    scope=prime.ScopeDefinition(model, label_expression="ground patch* wheel"),
     update=True,
 )
 display.show()
@@ -185,7 +185,7 @@ wrap_part = mesh_util.wrap(
 print(model)
 display.plot(
     model,
-    scope=prime.ScopeDefinition(model, label_expression="ground, patch*, wheel"),
+    scope=prime.ScopeDefinition(model, label_expression="ground patch* wheel"),
     update=True,
 )
 display.show()

--- a/examples/gallery/13_pyvista_graphics.py
+++ b/examples/gallery/13_pyvista_graphics.py
@@ -50,25 +50,28 @@ nine visualization stages:
    ID annotations
 8. **Per-element face coloring** — individual mesh face cells colored uniquely
    via ``cell_data`` scalars
-9. **ColorByType modes** — reading and meshing structural parts to show
-   colored by ZONE, ZONELET, and PART using direct ``color_matrix`` indexing
+9. **ColorByType modes** — reading and meshing structural parts, then coloring
+   the same model by ZONE, ZONELET, and PART through ``set_color_by_type()``
 
 Key data model concepts demonstrated:
 
+- **Shared actors**: high-level plotting merges the display entities of a part
+  into a handful of actors and keeps entity identity on the mesh as cell data,
+  so picking, coloring, and visibility stay per entity without one actor each
 - **Multi-part models**: polydata dict is keyed by ``part_id``; each part
   contains its own faces, edges, control points, and spline surfaces
 - **DisplayMeshType** filtering (``TOPOFACE``, ``TOPOEDGE``, ``FACEZONELET``,
   ``EDGEZONELET``) to distinguish entity types
 - **DisplayMeshInfo** metadata (``id``, ``zone_name``, ``zone_id``,
-  ``part_id``, ``part_name``, ``has_mesh``, ``display_mesh_type``) preserved
-  through ``info_actor_map``
+  ``part_id``, ``part_name``, ``has_mesh``, ``display_mesh_type``) available
+  from polydata and, for custom ``add_mesh`` calls, registered for the widgets
 - **Labels vs Zones**: labels are overlapping CAD metadata queried via
   ``Part.get_labels()``; zones are non-overlapping mesh groupings from
   ``Part.get_face_zones()`` / ``Part.get_volume_zones()``
 - **Edge type colors**: edges carry type-based RGB data in their ``"colors"``
   array (red, black, cyan, magenta, yellow, purple by edge type)
-- **ColorByType**: ``get_scalar_colors()`` supports ZONE, ZONELET, and PART
-  coloring modes; the built-in ``ColorByTypeWidget`` cycles between them
+- **ColorByType**: ``set_color_by_type()`` recolors by ZONE, ZONELET, or PART;
+  the built-in ``ColorByTypeWidget`` cycles between them
 - **Polydata access**: ``model.as_polydata()`` returns a dict keyed by part ID
   with ``"faces"`` (tuples of ``MeshObjectPlot, DisplayMeshInfo``),
   ``"edges"`` (``MeshObjectPlot``), ``"ctrlpts"``, and ``"splinesurf"`` lists
@@ -90,7 +93,7 @@ import pyvista as pv
 
 import ansys.meshing.prime as prime
 from ansys.meshing.prime.core.mesh import DisplayMeshType
-from ansys.meshing.prime.graphics.plotter import ColorByType, PrimePlotter, color_matrix
+from ansys.meshing.prime.graphics.plotter import ColorByType, PrimePlotter
 
 
 def make_distinct_colors(n):
@@ -532,7 +535,7 @@ plotter.show(title="Plot 7 \u2014 Face Zonelets with IDs")
 # Demonstrates:
 #   - Assigning per-cell RGB scalars via cell_data on a copy of the mesh
 #   - plotter.add_mesh() with scalars='RGB', rgb=True, and metadata
-#   - Metadata automatically registered in info_actor_map
+#   - Metadata registered so the built-in widgets can still find the mesh
 
 plotter = PrimePlotter()
 rng = np.random.default_rng(seed=42)
@@ -573,8 +576,8 @@ plotter.show(title="Plot 8 \u2014 Per-Element Face Colors")
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Demonstrates:
 #   - ColorByType enum (ZONE, ZONELET, PART) for different coloring strategies
-#   - Same mesh data rendered three ways using the color_matrix palette
-#   - This is the logic used by the built-in ColorByType widget
+#   - set_color_by_type() recoloring the shared actors without rebuilding them
+#   - The same path used by the built-in ColorByType widget
 
 # Load pipe tee CAD geometry and mesh as separate parts to show color by type
 pipe_tee = prime.examples.download_pipe_tee_pmdat()
@@ -583,35 +586,13 @@ mesh_util.read(file_name=pipe_tee)
 mesh_util.surface_mesh(min_size=5, max_size=25)
 mesh_util.volume_mesh()
 
-# getting updated data for the new mesh
-volume_graphics_data = model.as_polydata(update=True)
-
 # For reference after the structural parts are meshed the model contains:
 print(model)
 
-num_colors = int(color_matrix.size / 3)
-
 for color_mode in [ColorByType.ZONE, ColorByType.ZONELET, ColorByType.PART]:
     plotter = PrimePlotter()
-
-    for part_id, part_data in volume_graphics_data.items():
-        for entity_type, entity_list in part_data.items():
-            if entity_type == "faces":
-                for item in entity_list:
-                    if item is None:
-                        continue
-                    polydata, metadata = item
-                    if metadata.has_mesh:
-                        # Apply ColorByType logic (same as ColorByTypeWidget)
-                        if color_mode == ColorByType.ZONELET:
-                            color = color_matrix[metadata.id % num_colors].tolist()
-                        elif color_mode == ColorByType.PART:
-                            color = color_matrix[metadata.part_id % num_colors].tolist()
-                        else:  # ZONE
-                            color = color_matrix[metadata.zone_id % num_colors].tolist()
-                        plotter.add_mesh(
-                            polydata, metadata, color=color, opacity=1.0, show_edges=True
-                        )
+    plotter.plot(model, update=True)
+    plotter.set_color_by_type(color_mode)
 
     mode_name = color_mode.name
     plotter.add_text(

--- a/examples/gallery_beta/11_solder_ball.py
+++ b/examples/gallery_beta/11_solder_ball.py
@@ -60,6 +60,7 @@ Procedure
 """
 
 # sphinx_gallery_tags = ["Semiconductor", "Hex", "Stacker", "Morph", "Connect", "Beta"]
+# sphinx_gallery_thumbnail_number = 6
 
 ###############################################################################
 # Import modules

--- a/src/ansys/meshing/prime/core/mesh.py
+++ b/src/ansys/meshing/prime/core/mesh.py
@@ -77,6 +77,15 @@ class DisplayMeshType(enum.IntEnum):
     SPLINESURFACE = 5
 
 
+#: Cell array carrying the display entity (topoface or face zonelet) each cell belongs to.
+#: Display entities are merged into shared render batches, so this array is what restores
+#: per entity identity for picking, coloring, and visibility.
+ENTITY_ID_ARRAY = "prime_entity_id"
+
+#: Cell array carrying the RGB color currently applied to each cell.
+ENTITY_COLOR_ARRAY = "colors"
+
+
 class DisplayMeshInfo:
     """Contains the mesh information to display.
 
@@ -126,6 +135,281 @@ class DisplayMeshInfo:
         self.has_mesh = has_mesh
         self.render_mesh = render_mesh
         self.element_edges = element_edges
+
+
+class RenderBatch:
+    """A set of display entities merged into a single renderable mesh.
+
+    Display entities that share a draw style are merged so that the renderer draws
+    them as one actor. The entity each cell came from is kept in the
+    :data:`ENTITY_ID_ARRAY` cell array, so picking, coloring, and visibility stay
+    per entity even though the geometry is shared.
+
+    Parameters
+    ----------
+    mesh : pv.PolyData
+        Merged geometry of every entity in the batch.
+    infos : Dict[int, DisplayMeshInfo]
+        Display information of each entity in the batch, keyed by entity ID.
+    part_id : int
+        ID of the part the batch belongs to.
+    show_edges : bool, default: False
+        Whether the renderer draws the element edges of the batch itself.
+    """
+
+    def __init__(
+        self,
+        mesh: "pv.PolyData",
+        infos: Dict[int, DisplayMeshInfo],
+        part_id: int,
+        show_edges: bool = False,
+    ) -> None:
+        """Initialize the render batch."""
+        self.mesh = mesh
+        self.infos = infos
+        self.part_id = part_id
+        self.show_edges = show_edges
+
+    @property
+    def entity_ids(self) -> np.ndarray:
+        """Entity ID of every cell in the batch.
+
+        Returns
+        -------
+        np.ndarray
+            Entity ID of every cell in the batch.
+        """
+        return self.mesh.cell_data[ENTITY_ID_ARRAY]
+
+    def apply_colors(self, color_type: ColorByType = None) -> None:
+        """Color the cells of the batch by the given entity property.
+
+        Parameters
+        ----------
+        color_type : ColorByType, default: None
+            Entity property to take the color from. When this is ``None``, the
+            property is chosen by :func:`default_color_key`.
+        """
+        self.mesh.cell_data[ENTITY_COLOR_ARRAY] = compute_entity_colors(
+            self.infos, self.entity_ids, color_type
+        )
+
+
+def default_color_key(info: DisplayMeshInfo) -> int:
+    """Get the property a display entity is colored by before a color mode is chosen.
+
+    Which property this is depends on the type of the entity: mesh faces are colored
+    by part and topology edges by their own ID, while everything else is colored by
+    zone.
+
+    Parameters
+    ----------
+    info : DisplayMeshInfo
+        Display information of the entity.
+
+    Returns
+    -------
+    int
+        Value to take the color from.
+    """
+    mesh_type = info.display_mesh_type
+    if mesh_type == DisplayMeshType.TOPOEDGE:
+        return info.id
+    if mesh_type == DisplayMeshType.FACEZONELET:
+        return info.part_id
+    return info.zone_id
+
+
+def entity_color(info: DisplayMeshInfo, color_type: ColorByType = None):
+    """Get the color of a display entity for the given color mode.
+
+    Parameters
+    ----------
+    info : DisplayMeshInfo
+        Display information of the entity.
+    color_type : ColorByType, default: None
+        Entity property to take the color from. When this is ``None``, the property
+        is chosen by :func:`default_color_key`.
+
+    Returns
+    -------
+    np.ndarray
+        RGB color of the entity.
+    """
+    num_colors = int(color_matrix.size / 3)
+    if color_type is None:
+        key = default_color_key(info)
+    elif color_type == ColorByType.ZONELET:
+        key = info.id
+    elif color_type == ColorByType.PART:
+        key = info.part_id
+    else:
+        key = info.zone_id
+    return color_matrix[key % num_colors]
+
+
+def compute_entity_colors(
+    infos: Dict[int, DisplayMeshInfo],
+    entity_ids: np.ndarray,
+    color_type: ColorByType = None,
+) -> np.ndarray:
+    """Compute the per cell colors of a merged mesh.
+
+    Parameters
+    ----------
+    infos : Dict[int, DisplayMeshInfo]
+        Display information of each entity, keyed by entity ID.
+    entity_ids : np.ndarray
+        Entity ID of every cell of the merged mesh.
+    color_type : ColorByType, default: None
+        Entity property to take the color from. When this is ``None``, the property
+        is chosen by :func:`default_color_key`.
+
+    Returns
+    -------
+    np.ndarray
+        RGB color of every cell of the merged mesh.
+    """
+    entity_ids = np.asarray(entity_ids)
+    if entity_ids.size == 0:
+        return np.empty((0, 3), dtype=np.uint8)
+    # the palette is built once per entity and then indexed per cell, so the cost
+    # scales with the number of entities rather than the number of cells
+    unique_ids, inverse = np.unique(entity_ids, return_inverse=True)
+    palette = np.array(
+        [entity_color(infos[entity_id], color_type) for entity_id in unique_ids],
+        dtype=np.uint8,
+    )
+    return palette[inverse]
+
+
+def build_face_render_batches(face_entries: List, part_id: int) -> List[RenderBatch]:
+    """Merge the face entities of a part into render batches.
+
+    Entities are grouped by whether the renderer can draw their element edges itself,
+    since that is a property of the actor rather than of the geometry. This yields at
+    most two batches per part instead of one actor per entity.
+
+    Parameters
+    ----------
+    face_entries : List
+        ``(MeshObjectPlot, DisplayMeshInfo)`` pairs of the faces of a part.
+    part_id : int
+        ID of the part the faces belong to.
+
+    Returns
+    -------
+    List[RenderBatch]
+        Render batches of the faces of the part.
+    """
+    grouped = {}
+    for entry in face_entries:
+        if entry is None:
+            continue
+        mesh_object, info = entry
+        # zonelets that VTK cannot tessellate acceptably carry an explicit
+        # triangulation to shade in place of their own facets
+        geometry = info.render_mesh if info.render_mesh is not None else mesh_object.mesh
+        if geometry is None or geometry.n_cells == 0:
+            continue
+        show_edges = bool(info.has_mesh and info.element_edges is None)
+        grouped.setdefault(show_edges, []).append((geometry, info))
+
+    batches = []
+    for show_edges, items in grouped.items():
+        merged = _merge_geometry([geometry for geometry, _ in items])
+        if merged is None:
+            continue
+        merged.cell_data[ENTITY_ID_ARRAY] = np.repeat(
+            [info.id for _, info in items], [geometry.n_cells for geometry, _ in items]
+        )
+        batch = RenderBatch(
+            mesh=merged,
+            infos={info.id: info for _, info in items},
+            part_id=part_id,
+            show_edges=show_edges,
+        )
+        batch.apply_colors()
+        batches.append(batch)
+    return batches
+
+
+def build_element_edge_mesh(face_entries: List) -> "pv.PolyData":
+    """Merge the element outlines of the face entities of a part.
+
+    Parameters
+    ----------
+    face_entries : List
+        ``(MeshObjectPlot, DisplayMeshInfo)`` pairs of the faces of a part.
+
+    Returns
+    -------
+    pv.PolyData
+        Merged outlines, or ``None`` when no entity carries outlines.
+    """
+    outlines = []
+    entity_ids = []
+    for entry in face_entries:
+        if entry is None:
+            continue
+        _, info = entry
+        if info.element_edges is None or info.element_edges.n_cells == 0:
+            continue
+        outlines.append(info.element_edges)
+        entity_ids.append(info.id)
+
+    merged = _merge_geometry(outlines)
+    if merged is not None:
+        merged.cell_data[ENTITY_ID_ARRAY] = np.repeat(
+            entity_ids, [outline.n_cells for outline in outlines]
+        )
+    return merged
+
+
+def build_edge_render_mesh(edge_entries: List) -> "pv.PolyData":
+    """Merge the edge entities of a part into a single mesh.
+
+    Edges are not pickable, so they carry their colors rather than entity IDs.
+
+    Parameters
+    ----------
+    edge_entries : List
+        ``MeshObjectPlot`` objects of the edges of a part.
+
+    Returns
+    -------
+    pv.PolyData
+        Merged edges, or ``None`` when the part has no edges to draw.
+    """
+    edges = [
+        entry.mesh
+        for entry in edge_entries
+        if entry is not None and entry.mesh is not None and entry.mesh.n_cells > 0
+    ]
+    return _merge_geometry(edges)
+
+
+def _merge_geometry(pieces: List) -> "pv.PolyData":
+    """Concatenate meshes while preserving their order.
+
+    Points are not merged across pieces, so cells stay in piece order and the entity
+    of each cell can be recovered by repeating the entity of its piece.
+
+    Parameters
+    ----------
+    pieces : List
+        Meshes to concatenate.
+
+    Returns
+    -------
+    pv.PolyData
+        Concatenated mesh, or ``None`` when there is nothing to concatenate.
+    """
+    if not pieces:
+        return None
+    if len(pieces) == 1:
+        return pieces[0].copy()
+    return pv.merge(pieces, merge_points=False)
 
 
 def compute_distance(point1, point2) -> float:
@@ -527,7 +811,11 @@ class Mesh(MeshInfo):
         edge.lines = cells
         ecolor = np.array(self.get_edge_color(edge_facet_res, index))
         colors = np.tile(ecolor, (len(segments), 1))
-        edge["colors"] = colors
+        # a closed edge has as many points as segments, so the colors have to name
+        # the association they belong to rather than let it be inferred from length
+        edge.cell_data[ENTITY_COLOR_ARRAY] = colors
+        if segments:
+            edge.set_active_scalars(ENTITY_COLOR_ARRAY, preference="cell")
         if edge.n_points > 0:
             return MeshObjectPlot(part, edge)
 
@@ -605,15 +893,24 @@ class Mesh(MeshInfo):
         if len(set(parts).intersection(set(self._parts_polydata.keys()))) != len(parts):
             self.update_pd(parts)
         scoped_pd = {}
-        scope_def = scope
         for part_id in parts:
             part = self._model.get_part(part_id)
-            scope_def.part_expression = part.name
+            # narrow the query to this part without rewriting the caller's scope;
+            # mutating part_expression on the input silently changes later plots
+            # that reuse the same ScopeDefinition
+            part_scope = prime.ScopeDefinition(
+                model=self._model,
+                entity_type=scope.entity_type,
+                evaluation_type=scope.evaluation_type,
+                part_expression=part.name,
+                label_expression=scope.label_expression,
+                zone_expression=scope.zone_expression,
+            )
             disp_data = None
             disp_ids = []
             if scope.entity_type == prime.ScopeEntity.FACEZONELETS:
                 disp_ids = self._model.control_data.get_scope_face_zonelets(
-                    scope=scope_def, params=prime.ScopeZoneletParams(model=self._model)
+                    scope=part_scope, params=prime.ScopeZoneletParams(model=self._model)
                 )
                 disp_data = self._parts_polydata[part_id]["faces"]
 

--- a/src/ansys/meshing/prime/graphics/plotter.py
+++ b/src/ansys/meshing/prime/graphics/plotter.py
@@ -127,6 +127,8 @@ class PrimePlotter(Plotter):
         self._hidden_entities = set()
         # merged element outlines of each part, keyed by part ID
         self._element_edge_meshes = {}
+        # geometry handed to each actor, keyed by actor; the mapper does not own it
+        self._drawn_geometry = {}
         # no color mode is chosen until a caller or the widget picks one
         self._color_type = None
         self._add_widgets()
@@ -349,8 +351,11 @@ class PrimePlotter(Plotter):
         """
         outlines = build_element_edge_mesh(face_entries)
         for batch in build_face_render_batches(face_entries, part_id):
+            # the actor draws a copy: the batch stays the whole geometry so that
+            # hidden cells can be taken away from it and put back
+            drawn = batch.mesh.copy()
             actor = self.scene.add_mesh(
-                batch.mesh,
+                drawn,
                 scalars=ENTITY_COLOR_ARRAY,
                 rgb=True,
                 show_edges=batch.show_edges,
@@ -361,16 +366,20 @@ class PrimePlotter(Plotter):
                 # so the shaded surface is pushed back to stop it z-fighting the lines
                 self._offset_polygons(actor)
             self._batches[actor] = batch
+            self._drawn_geometry[actor] = drawn
             self._entity_infos.update(batch.infos)
 
         if outlines is not None:
             self._element_edge_meshes[part_id] = outlines
-            self._element_edge_actors[part_id] = self.scene.add_mesh(
-                outlines,
+            drawn_outlines = outlines.copy()
+            outline_actor = self.scene.add_mesh(
+                drawn_outlines,
                 color=pv.global_theme.edge_color,
                 line_width=1,
                 pickable=False,
             )
+            self._element_edge_actors[part_id] = outline_actor
+            self._drawn_geometry[outline_actor] = drawn_outlines
 
     def _add_edges(self, edge_entries: List) -> None:
         """Draw the edges of a part.
@@ -430,7 +439,7 @@ class PrimePlotter(Plotter):
 
         # resolve against what is drawn rather than the full batch, so that hidden
         # entities cannot be picked through the entities that are still shown
-        mesh = actor.mapper.dataset
+        mesh = self._drawn_geometry.get(actor)
         if mesh is None or mesh.n_cells == 0:
             return True
 
@@ -592,14 +601,34 @@ class PrimePlotter(Plotter):
         -------
         pyvista.DataSet
             The mesh itself when nothing it holds is hidden, and a copy holding only
-            the visible cells otherwise.
+            the visible cells otherwise. The type of the mesh is kept, so that the
+            geometry can be copied straight over what is drawn.
         """
         if not self._hidden_entities:
             return mesh
         hidden = np.isin(entity_ids, list(self._hidden_entities))
         if not hidden.any():
             return mesh
-        return mesh.extract_cells(np.flatnonzero(~hidden))
+        return mesh.remove_cells(np.flatnonzero(hidden), inplace=False)
+
+    def _draw(self, actor, mesh) -> None:
+        """Update the geometry an actor draws.
+
+        The geometry is copied over the mesh the actor was built from instead of
+        being handed to the mapper as a new data set: a mapper keeps no reference of
+        its own to what it is given, and replacing its input leaves the actor blank.
+
+        Parameters
+        ----------
+        actor : pyvista.Actor
+            Actor to draw the geometry with.
+        mesh : pyvista.DataSet
+            Geometry to draw.
+        """
+        drawn = self._drawn_geometry.get(actor)
+        if drawn is None or drawn is mesh:
+            return
+        drawn.copy_from(mesh)
 
     def _apply_visibility(self) -> None:
         """Draw only the cells of the entities that are visible.
@@ -609,13 +638,13 @@ class PrimePlotter(Plotter):
         drawn geometry has to hold the visible cells and nothing else.
         """
         for actor, batch in self._batches.items():
-            actor.mapper.dataset = self._visible_geometry(batch.mesh, batch.entity_ids)
+            self._draw(actor, self._visible_geometry(batch.mesh, batch.entity_ids))
 
         for part_id, outlines in self._element_edge_actors.items():
             mesh = self._element_edge_meshes.get(part_id)
             if mesh is None or ENTITY_ID_ARRAY not in mesh.cell_data:
                 continue
-            outlines.mapper.dataset = self._visible_geometry(mesh, mesh.cell_data[ENTITY_ID_ARRAY])
+            self._draw(outlines, self._visible_geometry(mesh, mesh.cell_data[ENTITY_ID_ARRAY]))
         self._update_entity_labels()
         self.render()
 
@@ -658,6 +687,7 @@ class PrimePlotter(Plotter):
         self._entity_labels = {}
         self._hidden_entities = set()
         self._element_edge_meshes = {}
+        self._drawn_geometry = {}
         self._add_widgets()
 
     def add_scope(self, model: Model, scope: prime.ScopeDefinition, update: bool = False) -> None:

--- a/src/ansys/meshing/prime/graphics/plotter.py
+++ b/src/ansys/meshing/prime/graphics/plotter.py
@@ -21,7 +21,6 @@
 # SOFTWARE.
 """Module for the plotter."""
 
-import enum
 import warnings
 from typing import Any, Dict, List, Optional
 
@@ -29,39 +28,29 @@ import numpy as np
 import pyvista as pv
 from ansys.tools.visualization_interface import Plotter
 from ansys.tools.visualization_interface.backends.pyvista import PyVistaBackend
+from ansys.tools.visualization_interface.utils.color import Color
+from vtkmodules.vtkCommonDataModel import vtkDataSetAttributes
 
 import ansys.meshing.prime as prime
-from ansys.meshing.prime.core.mesh import DisplayMeshInfo
+
+# kept importable from here for callers that build their own coloring
+from ansys.meshing.prime.core.mesh import color_matrix  # noqa: F401
+from ansys.meshing.prime.core.mesh import (
+    ENTITY_COLOR_ARRAY,
+    ENTITY_ID_ARRAY,
+    ColorByType,
+    DisplayMeshInfo,
+    build_edge_render_mesh,
+    build_element_edge_mesh,
+    build_face_render_batches,
+    compute_entity_colors,
+    entity_color,
+)
 from ansys.meshing.prime.core.model import Model
 from ansys.meshing.prime.graphics.widgets.color_by_type import ColorByTypeWidget
 from ansys.meshing.prime.graphics.widgets.hide_picked import HidePicked
 from ansys.meshing.prime.graphics.widgets.picked_info import PickedInfo
 from ansys.meshing.prime.graphics.widgets.toggle_edges import ToggleEdges
-
-color_matrix = np.array(
-    [
-        [155, 186, 126],
-        [242, 236, 175],
-        [255, 187, 131],
-        [194, 187, 97],
-        [159, 131, 169],
-        [157, 190, 139],
-        [233, 218, 158],
-        [254, 252, 196],
-        [246, 210, 148],
-        [215, 208, 198],
-        [196, 235, 145],
-    ]
-)
-
-
-class ColorByType(enum.IntEnum):
-    """Contains the zone types to display."""
-
-    ZONE = 0
-    ZONELET = 1
-    PART = 2
-
 
 # Depth-buffer offset applied to a face actor whose element outlines are drawn as a
 # separate line actor, so that the shaded surface cannot z-fight with those lines.
@@ -69,12 +58,47 @@ class ColorByType(enum.IntEnum):
 POLYGON_OFFSET_FACTOR = 1.0
 POLYGON_OFFSET_UNITS = 1.0
 
+# VTK skips cells flagged as hidden in the ghost array, which is how individual
+# display entities are hidden without rebuilding the mesh they share.
+_HIDDEN_CELL = vtkDataSetAttributes.HIDDENCELL
+_GHOST_ARRAY = "vtkGhostType"
+
+
+class _EntityPickingBackend(PyVistaBackend):
+    """PyVista backend that resolves a pick to the display entity under the cursor.
+
+    Display entities of a part share an actor, so the actor alone no longer
+    identifies what was picked. Picks that land on a shared actor are resolved
+    against the cell the pick point falls on, and anything else is left to the
+    generic backend.
+    """
+
+    prime_plotter = None
+
+    def picker_callback(self, actor: "pv.Actor") -> None:
+        """Select the display entity under the cursor.
+
+        Parameters
+        ----------
+        actor : pv.Actor
+            Actor the pick landed on.
+        """
+        plotter = self.prime_plotter
+        if plotter is not None and plotter._pick_entity(actor, self._pl.scene.picked_point):
+            return
+        super().picker_callback(actor)
+
 
 class PrimePlotter(Plotter):
     """Create a plotter for PyPrimeMesh models.
 
     This plotter is a wrapper around the PyAnsys generic plotter
     with additional functionality for PyPrimeMesh.
+
+    Display entities of a part are merged into a small number of actors that are
+    drawn together, rather than one actor per entity. The entity each cell belongs
+    to is kept on the mesh, so picking, coloring, and visibility remain per entity
+    while the scene stays cheap to render and to export.
 
     Parameters
     ----------
@@ -85,16 +109,31 @@ class PrimePlotter(Plotter):
     """
 
     def __init__(
-        self, use_trame: Optional[bool] = None, allow_picking: Optional[bool] = True
+        self,
+        use_trame: Optional[bool] = None,
+        allow_picking: Optional[bool] = True,
     ) -> None:
         """Initialize the widget."""
-        self._backend = PyVistaBackend(use_trame=use_trame, allow_picking=allow_picking)
+        self._backend = _EntityPickingBackend(use_trame=use_trame, allow_picking=allow_picking)
+        self._backend.prime_plotter = self
         super().__init__(backend=self._backend)
 
-        # info of the actor to pass to picked info widget
+        # actors added through add_mesh(..., metadata=...), keyed for the widgets
         self._info_actor_map = {}
-        # element outlines drawn separately, keyed by the face actor they belong to
+        # element outlines drawn separately, keyed by part ID for model faces and
+        # by face actor for meshes added through add_mesh
         self._element_edge_actors = {}
+        # merged rendering state, keyed by the actor that draws each batch
+        self._batches = {}
+        self._entity_infos = {}
+        self._picked_entities = {}
+        self._hidden_entities = set()
+        # no color mode is chosen until a caller or the widget picks one
+        self._color_type = None
+        self._add_widgets()
+
+    def _add_widgets(self) -> None:
+        """Attach the PyPrimeMesh widgets to the backend."""
         self._backend.add_widget(ToggleEdges(self))
         self._backend.add_widget(ColorByTypeWidget(self))
         self._backend.add_widget(HidePicked(self))
@@ -102,7 +141,7 @@ class PrimePlotter(Plotter):
 
     @property
     def info_actor_map(self) -> Dict:
-        """Get the information actor map for the selected information widget.
+        """Get the information actor map for meshes added with metadata.
 
         Returns
         -------
@@ -113,7 +152,7 @@ class PrimePlotter(Plotter):
 
     @info_actor_map.setter
     def info_actor_map(self, value: Dict) -> None:
-        """Set the information actor map for the selected information widget.
+        """Set the information actor map for meshes added with metadata.
 
         Parameters
         ----------
@@ -129,7 +168,7 @@ class PrimePlotter(Plotter):
         Returns
         -------
         Dict
-            Actor holding the outlines of each face actor that has them.
+            Actor holding the outlines of each part (or face actor) that has them.
         """
         return self._element_edge_actors
 
@@ -137,6 +176,28 @@ class PrimePlotter(Plotter):
     def scene(self):
         """Get the underlying PyVista plotter scene for direct rendering control."""
         return self._backend.pv_interface.scene
+
+    @property
+    def entity_infos(self) -> Dict[int, DisplayMeshInfo]:
+        """Get the display information of every entity in the scene, keyed by entity ID.
+
+        Returns
+        -------
+        Dict[int, DisplayMeshInfo]
+            Display information of every entity in the scene.
+        """
+        return self._entity_infos
+
+    @property
+    def picked_entities(self) -> Dict[int, DisplayMeshInfo]:
+        """Get the display information of the picked entities, keyed by entity ID.
+
+        Returns
+        -------
+        Dict[int, DisplayMeshInfo]
+            Display information of the picked entities.
+        """
+        return self._picked_entities
 
     def get_scalar_colors(self, mesh_info: DisplayMeshInfo) -> np.ndarray:
         """Get the scalar colors for the mesh.
@@ -151,14 +212,7 @@ class PrimePlotter(Plotter):
         np.ndarray
             Scalar colors for the mesh.
         """
-        mesh_type = mesh_info.display_mesh_type
-        num_colors = int(color_matrix.size / 3)
-        if mesh_type == ColorByType.ZONELET:
-            return color_matrix[mesh_info.id % num_colors].tolist()
-        elif mesh_type == ColorByType.PART:
-            return color_matrix[mesh_info.part_id % num_colors].tolist()
-        else:
-            return color_matrix[mesh_info.zone_id % num_colors].tolist()
+        return entity_color(mesh_info).tolist()
 
     def add_mesh(self, mesh, metadata=None, **pyvista_kwargs):
         """Add a mesh or MeshObjectPlot to the scene with optional metadata tracking.
@@ -168,7 +222,8 @@ class PrimePlotter(Plotter):
         mesh: pyvista.DataSet or MeshObjectPlot
             A raw PyVista mesh or a MeshObjectPlot (which has a ``.mesh`` attribute).
         metadata : DisplayMeshInfo, optional
-            If provided, registers the actor in ``info_actor_map`` for widget support.
+            If provided, registers the actor in ``info_actor_map`` so the built-in
+            widgets can color, hide, and report it.
         **pyvista_kwargs
             Additional keyword arguments passed to ``scene.add_mesh()``.
 
@@ -252,37 +307,10 @@ class PrimePlotter(Plotter):
         for part_id, part_polydata in model_pd.items():
             # proceed if scope won't be used or if the part is in the scope
             if "faces" in part_polydata.keys():
-                for face_mesh_part, face_mesh_info in part_polydata["faces"]:
-
-                    # These operations could be done downstream,
-                    # but we need the actor for the picked info widget
-                    colors = self.get_scalar_colors(face_mesh_info)
-                    has_mesh = face_mesh_info.has_mesh
-                    element_edges = face_mesh_info.element_edges
-                    render_mesh = face_mesh_info.render_mesh
-                    actor = self._backend.pv_interface.scene.add_mesh(
-                        face_mesh_part.mesh if render_mesh is None else render_mesh,
-                        show_edges=has_mesh and element_edges is None,
-                        color=colors,
-                        pickable=True,
-                    )
-                    face_mesh_part.actor = actor
-                    self._backend.pv_interface._object_to_actors_map[actor] = face_mesh_part
-                    self._info_actor_map[actor] = face_mesh_info
-                    if element_edges is not None:
-                        self._add_element_edges(actor, element_edges)
+                self._add_merged_faces(part_id, part_polydata["faces"])
 
             if "edges" in part_polydata.keys():
-                for edge_mesh_part in part_polydata["edges"]:
-                    actor = self._backend.pv_interface.scene.add_mesh(
-                        edge_mesh_part.mesh,
-                        # scalars="colors",
-                        rgb=True,
-                        pickable=False,
-                        line_width=4,
-                    )
-                    edge_mesh_part.actor = actor
-                    self._backend._object_to_actors_map[actor] = edge_mesh_part
+                self._add_edges(part_polydata["edges"])
 
             if "ctrlpoints" in part_polydata.keys():
                 for ctrlpoint_mesh_part in part_polydata["ctrlpoints"]:
@@ -310,27 +338,232 @@ class PrimePlotter(Plotter):
                     spline_mesh_part.actor = actor
                     self._backend._object_to_actors_map[actor] = spline_mesh_part
 
-    def _add_element_edges(self, face_actor, element_edges) -> None:
-        """Draw element outlines that the face actor cannot draw itself.
+    def _add_merged_faces(self, part_id: int, face_entries: List) -> None:
+        """Draw the faces of a part as a small number of shared actors.
 
         Parameters
         ----------
-        face_actor : pyvista.Actor
-            Actor of the shaded faces the outlines belong to.
-        element_edges : pyvista.PolyData
-            Element outlines to draw.
+        part_id : int
+            ID of the part the faces belong to.
+        face_entries : List
+            ``(MeshObjectPlot, DisplayMeshInfo)`` pairs of the faces of the part.
         """
-        mapper = face_actor.GetMapper()
+        outlines = build_element_edge_mesh(face_entries)
+        for batch in build_face_render_batches(face_entries, part_id):
+            actor = self.scene.add_mesh(
+                batch.mesh,
+                scalars=ENTITY_COLOR_ARRAY,
+                rgb=True,
+                show_edges=batch.show_edges,
+                pickable=True,
+            )
+            if outlines is not None and not batch.show_edges:
+                # the outlines of these entities are drawn as separate line geometry,
+                # so the shaded surface is pushed back to stop it z-fighting the lines
+                self._offset_polygons(actor)
+            self._batches[actor] = batch
+            self._entity_infos.update(batch.infos)
+
+        if outlines is not None:
+            self._element_edge_actors[part_id] = self.scene.add_mesh(
+                outlines,
+                color=pv.global_theme.edge_color,
+                line_width=1,
+                pickable=False,
+            )
+
+    def _add_edges(self, edge_entries: List) -> None:
+        """Draw the edges of a part.
+
+        Parameters
+        ----------
+        edge_entries : List
+            ``MeshObjectPlot`` objects of the edges of the part.
+        """
+        merged = build_edge_render_mesh(edge_entries)
+        if merged is None:
+            return
+        # merging does not carry over which array is active, so the colors
+        # the edges were built with have to be named explicitly
+        has_colors = ENTITY_COLOR_ARRAY in merged.cell_data
+        self.scene.add_mesh(
+            merged,
+            scalars=ENTITY_COLOR_ARRAY if has_colors else None,
+            rgb=has_colors,
+            pickable=False,
+            line_width=4,
+        )
+
+    @staticmethod
+    def _offset_polygons(actor) -> None:
+        """Push a shaded surface back so coincident line geometry stays visible.
+
+        Parameters
+        ----------
+        actor : pyvista.Actor
+            Actor of the shaded faces to push back.
+        """
+        mapper = actor.GetMapper()
         mapper.SetResolveCoincidentTopologyToPolygonOffset()
         mapper.SetRelativeCoincidentTopologyPolygonOffsetParameters(
             POLYGON_OFFSET_FACTOR, POLYGON_OFFSET_UNITS
         )
-        self._element_edge_actors[face_actor] = self._backend.pv_interface.scene.add_mesh(
-            element_edges,
-            color=pv.global_theme.edge_color,
-            line_width=1,
-            pickable=False,
+
+    def _pick_entity(self, actor, point) -> bool:
+        """Toggle the selection of the entity the pick landed on.
+
+        Parameters
+        ----------
+        actor : pyvista.Actor
+            Actor the pick landed on.
+        point : Sequence[float]
+            Point the pick landed on.
+
+        Returns
+        -------
+        bool
+            Whether the pick landed on a shared actor and was handled here.
+        """
+        batch = self._batches.get(actor)
+        if batch is None or point is None:
+            return False
+
+        cell_id = batch.mesh.find_closest_cell(list(point))
+        if cell_id < 0:
+            return True
+
+        entity_id = int(batch.entity_ids[cell_id])
+        if entity_id in self._picked_entities:
+            self._picked_entities.pop(entity_id)
+        else:
+            self._picked_entities[entity_id] = batch.infos[entity_id]
+        self.refresh_colors()
+        return True
+
+    def refresh_colors(self) -> None:
+        """Recolor every shared actor from the current color mode and selection."""
+        picked = Color.PICKED.value
+        highlight = np.array(pv.Color(picked).int_rgb, dtype=np.uint8)
+        for batch in self._batches.values():
+            colors = compute_entity_colors(batch.infos, batch.entity_ids, self._color_type)
+            if self._picked_entities:
+                selected = np.isin(batch.entity_ids, list(self._picked_entities))
+                colors[selected] = highlight
+            batch.mesh.cell_data[ENTITY_COLOR_ARRAY] = colors
+        self.render()
+
+    def set_color_by_type(self, color_type: "ColorByType") -> None:
+        """Color the entities in the scene by the given entity property.
+
+        Parameters
+        ----------
+        color_type : ColorByType
+            Entity property to take the color from.
+        """
+        self._color_type = color_type
+        for actor, info in self._info_actor_map.items():
+            actor.prop.color = entity_color(info, color_type).tolist()
+        self.refresh_colors()
+
+    @property
+    def selected_entity_infos(self) -> List[DisplayMeshInfo]:
+        """Get the display information of the entities that are currently picked.
+
+        Returns
+        -------
+        List[DisplayMeshInfo]
+            Display information of the entities that are currently picked.
+        """
+        infos = list(self._picked_entities.values())
+        # meshes added through add_mesh(..., metadata=...) are picked by the backend
+        picked = getattr(self._backend._custom_picker, "picked_dict", {})
+        infos.extend(
+            self._info_actor_map[mesh_object.actor]
+            for mesh_object in picked.values()
+            if getattr(mesh_object, "actor", None) in self._info_actor_map
         )
+        return infos
+
+    def set_entities_visible(self, entity_ids, visible: bool) -> None:
+        """Show or hide display entities without rebuilding the meshes they share.
+
+        Parameters
+        ----------
+        entity_ids : Iterable[int]
+            IDs of the entities to show or hide.
+        visible : bool
+            Whether to show the entities.
+        """
+        entity_ids = set(int(entity_id) for entity_id in entity_ids)
+        if visible:
+            self._hidden_entities -= entity_ids
+        else:
+            self._hidden_entities |= entity_ids
+
+        for actor, info in self._info_actor_map.items():
+            if info.id in entity_ids:
+                actor.visibility = visible
+                edge_actor = self._element_edge_actors.get(actor)
+                if edge_actor is not None:
+                    edge_actor.visibility = visible
+        self._apply_visibility()
+
+    def _apply_visibility(self) -> None:
+        """Flag the cells of hidden entities so that the renderer skips them."""
+        hidden = list(self._hidden_entities)
+        for actor, batch in self._batches.items():
+            ghosts = np.zeros(batch.mesh.n_cells, dtype=np.uint8)
+            if hidden:
+                ghosts[np.isin(batch.entity_ids, hidden)] = _HIDDEN_CELL
+            batch.mesh.cell_data[_GHOST_ARRAY] = ghosts
+
+        for outlines in self._element_edge_actors.values():
+            mesh = outlines.mapper.dataset
+            if mesh is None or ENTITY_ID_ARRAY not in mesh.cell_data:
+                continue
+            ghosts = np.zeros(mesh.n_cells, dtype=np.uint8)
+            if hidden:
+                ghosts[np.isin(mesh.cell_data[ENTITY_ID_ARRAY], hidden)] = _HIDDEN_CELL
+            mesh.cell_data[_GHOST_ARRAY] = ghosts
+        self.render()
+
+    def set_show_edges(self, show: bool) -> None:
+        """Show or hide the element edges of every entity that has a mesh.
+
+        Parameters
+        ----------
+        show : bool
+            Whether to show the element edges.
+        """
+        for actor, batch in self._batches.items():
+            if batch.show_edges:
+                actor.prop.show_edges = show
+        for actor, info in self._info_actor_map.items():
+            if info.has_mesh:
+                actor.prop.show_edges = show
+        # element outlines drawn as separate line geometry are hidden as a whole,
+        # since they are lines rather than the edges of a shaded actor
+        for outlines in self._element_edge_actors.values():
+            outlines.visibility = show
+        self.render()
+
+    def render(self) -> None:
+        """Redraw the scene if it is already on screen."""
+        scene = self.scene
+        if scene is not None and getattr(scene, "render_window", None) is not None:
+            scene.render()
+
+    def clear(self) -> None:
+        """Remove everything from the scene and reset the plotter."""
+        super().clear()
+        self._backend.prime_plotter = self
+        self._info_actor_map = {}
+        self._element_edge_actors = {}
+        self._batches = {}
+        self._entity_infos = {}
+        self._picked_entities = {}
+        self._hidden_entities = set()
+        self._add_widgets()
 
     def add_scope(self, model: Model, scope: prime.ScopeDefinition, update: bool = False) -> None:
         """Add a scope to the plotter.

--- a/src/ansys/meshing/prime/graphics/plotter.py
+++ b/src/ansys/meshing/prime/graphics/plotter.py
@@ -351,11 +351,8 @@ class PrimePlotter(Plotter):
         """
         outlines = build_element_edge_mesh(face_entries)
         for batch in build_face_render_batches(face_entries, part_id):
-            # the actor draws a copy: the batch stays the whole geometry so that
-            # hidden cells can be taken away from it and put back
-            drawn = batch.mesh.copy()
             actor = self.scene.add_mesh(
-                drawn,
+                batch.mesh,
                 scalars=ENTITY_COLOR_ARRAY,
                 rgb=True,
                 show_edges=batch.show_edges,
@@ -366,20 +363,19 @@ class PrimePlotter(Plotter):
                 # so the shaded surface is pushed back to stop it z-fighting the lines
                 self._offset_polygons(actor)
             self._batches[actor] = batch
-            self._drawn_geometry[actor] = drawn
+            self._drawn_geometry[actor] = batch.mesh
             self._entity_infos.update(batch.infos)
 
         if outlines is not None:
             self._element_edge_meshes[part_id] = outlines
-            drawn_outlines = outlines.copy()
             outline_actor = self.scene.add_mesh(
-                drawn_outlines,
+                outlines,
                 color=pv.global_theme.edge_color,
                 line_width=1,
                 pickable=False,
             )
             self._element_edge_actors[part_id] = outline_actor
-            self._drawn_geometry[outline_actor] = drawn_outlines
+            self._drawn_geometry[outline_actor] = outlines
 
     def _add_edges(self, edge_entries: List) -> None:
         """Draw the edges of a part.
@@ -612,11 +608,10 @@ class PrimePlotter(Plotter):
         return mesh.remove_cells(np.flatnonzero(hidden), inplace=False)
 
     def _draw(self, actor, mesh) -> None:
-        """Update the geometry an actor draws.
+        """Give an actor the geometry it has to draw.
 
-        The geometry is copied over the mesh the actor was built from instead of
-        being handed to the mapper as a new data set: a mapper keeps no reference of
-        its own to what it is given, and replacing its input leaves the actor blank.
+        The mesh is kept referenced here because a mapper does not hold one of its
+        own: geometry only the mapper points at is collected and nothing is drawn.
 
         Parameters
         ----------
@@ -625,10 +620,14 @@ class PrimePlotter(Plotter):
         mesh : pyvista.DataSet
             Geometry to draw.
         """
-        drawn = self._drawn_geometry.get(actor)
-        if drawn is None or drawn is mesh:
+        self._drawn_geometry[actor] = mesh
+        if mesh.n_cells == 0:
+            # a mapper that is handed an empty data set stops drawing for good, even
+            # once it is given geometry back, so an actor left with nothing is hidden
+            actor.visibility = False
             return
-        drawn.copy_from(mesh)
+        actor.visibility = True
+        actor.mapper.dataset = mesh
 
     def _apply_visibility(self) -> None:
         """Draw only the cells of the entities that are visible.

--- a/src/ansys/meshing/prime/graphics/plotter.py
+++ b/src/ansys/meshing/prime/graphics/plotter.py
@@ -29,7 +29,6 @@ import pyvista as pv
 from ansys.tools.visualization_interface import Plotter
 from ansys.tools.visualization_interface.backends.pyvista import PyVistaBackend
 from ansys.tools.visualization_interface.utils.color import Color
-from vtkmodules.vtkCommonDataModel import vtkDataSetAttributes
 
 import ansys.meshing.prime as prime
 
@@ -57,11 +56,6 @@ from ansys.meshing.prime.graphics.widgets.toggle_edges import ToggleEdges
 # The first value scales with the depth slope of the polygon, the second is constant.
 POLYGON_OFFSET_FACTOR = 1.0
 POLYGON_OFFSET_UNITS = 1.0
-
-# VTK skips cells flagged as hidden in the ghost array, which is how individual
-# display entities are hidden without rebuilding the mesh they share.
-_HIDDEN_CELL = vtkDataSetAttributes.HIDDENCELL
-_GHOST_ARRAY = "vtkGhostType"
 
 
 class _EntityPickingBackend(PyVistaBackend):
@@ -120,14 +114,19 @@ class PrimePlotter(Plotter):
 
         # actors added through add_mesh(..., metadata=...), keyed for the widgets
         self._info_actor_map = {}
-        # element outlines drawn separately, keyed by part ID for model faces and
-        # by face actor for meshes added through add_mesh
+        # element outlines drawn separately, keyed by the ID of the part they belong to
         self._element_edge_actors = {}
         # merged rendering state, keyed by the actor that draws each batch
         self._batches = {}
         self._entity_infos = {}
         self._picked_entities = {}
+        # point each entity was picked at, so its label can be restored
+        self._picked_points = {}
+        # label actor shown for each picked entity, keyed by entity ID
+        self._entity_labels = {}
         self._hidden_entities = set()
+        # merged element outlines of each part, keyed by part ID
+        self._element_edge_meshes = {}
         # no color mode is chosen until a caller or the widget picks one
         self._color_type = None
         self._add_widgets()
@@ -168,7 +167,7 @@ class PrimePlotter(Plotter):
         Returns
         -------
         Dict
-            Actor holding the outlines of each part (or face actor) that has them.
+            Actor holding the outlines of each part that has them.
         """
         return self._element_edge_actors
 
@@ -365,6 +364,7 @@ class PrimePlotter(Plotter):
             self._entity_infos.update(batch.infos)
 
         if outlines is not None:
+            self._element_edge_meshes[part_id] = outlines
             self._element_edge_actors[part_id] = self.scene.add_mesh(
                 outlines,
                 color=pv.global_theme.edge_color,
@@ -428,17 +428,88 @@ class PrimePlotter(Plotter):
         if batch is None or point is None:
             return False
 
-        cell_id = batch.mesh.find_closest_cell(list(point))
+        # resolve against what is drawn rather than the full batch, so that hidden
+        # entities cannot be picked through the entities that are still shown
+        mesh = actor.mapper.dataset
+        if mesh is None or mesh.n_cells == 0:
+            return True
+
+        cell_id = mesh.find_closest_cell(list(point))
         if cell_id < 0:
             return True
 
-        entity_id = int(batch.entity_ids[cell_id])
+        entity_id = int(mesh.cell_data[ENTITY_ID_ARRAY][cell_id])
         if entity_id in self._picked_entities:
             self._picked_entities.pop(entity_id)
+            self._picked_points.pop(entity_id, None)
+            self._remove_entity_label(entity_id)
         else:
             self._picked_entities[entity_id] = batch.infos[entity_id]
+            self._picked_points[entity_id] = np.asarray(point, dtype=float)
+            self._add_entity_label(entity_id)
         self.refresh_colors()
         return True
+
+    @staticmethod
+    def entity_label(info: DisplayMeshInfo) -> str:
+        """Get the text shown next to a picked entity.
+
+        Parameters
+        ----------
+        info : DisplayMeshInfo
+            Display information of the entity.
+
+        Returns
+        -------
+        str
+            Text shown next to the entity.
+        """
+        name = info.zone_name or info.part_name
+        return f"{name} ({info.id})" if name else str(info.id)
+
+    def _add_entity_label(self, entity_id: int) -> None:
+        """Label a picked entity at the point it was picked at.
+
+        Parameters
+        ----------
+        entity_id : int
+            ID of the entity to label.
+        """
+        point = self._picked_points.get(entity_id)
+        info = self._entity_infos.get(entity_id)
+        if point is None or info is None or entity_id in self._entity_labels:
+            return
+        if not getattr(self._backend, "_plot_picked_names", True):
+            return
+        self._entity_labels[entity_id] = self.scene.add_point_labels(
+            [point],
+            [self.entity_label(info)],
+            always_visible=True,
+            point_size=0,
+            render_points_as_spheres=False,
+            show_points=False,
+        )
+
+    def _remove_entity_label(self, entity_id: int) -> None:
+        """Remove the label of an entity, if it has one.
+
+        Parameters
+        ----------
+        entity_id : int
+            ID of the entity to remove the label of.
+        """
+        label = self._entity_labels.pop(entity_id, None)
+        if label is not None:
+            self.scene.remove_actor(label)
+
+    def _update_entity_labels(self) -> None:
+        """Show the label of every picked entity that is visible, and only those."""
+        for entity_id in list(self._entity_labels):
+            if entity_id in self._hidden_entities or entity_id not in self._picked_entities:
+                self._remove_entity_label(entity_id)
+        for entity_id in self._picked_entities:
+            if entity_id not in self._hidden_entities:
+                self._add_entity_label(entity_id)
 
     def refresh_colors(self) -> None:
         """Recolor every shared actor from the current color mode and selection."""
@@ -450,7 +521,9 @@ class PrimePlotter(Plotter):
                 selected = np.isin(batch.entity_ids, list(self._picked_entities))
                 colors[selected] = highlight
             batch.mesh.cell_data[ENTITY_COLOR_ARRAY] = colors
-        self.render()
+        # the drawn geometry is a copy of the batch whenever something is hidden,
+        # so it has to be rebuilt from the colors that were just written
+        self._apply_visibility()
 
     def set_color_by_type(self, color_type: "ColorByType") -> None:
         """Color the entities in the scene by the given entity property.
@@ -503,28 +576,47 @@ class PrimePlotter(Plotter):
         for actor, info in self._info_actor_map.items():
             if info.id in entity_ids:
                 actor.visibility = visible
-                edge_actor = self._element_edge_actors.get(actor)
-                if edge_actor is not None:
-                    edge_actor.visibility = visible
         self._apply_visibility()
 
-    def _apply_visibility(self) -> None:
-        """Flag the cells of hidden entities so that the renderer skips them."""
-        hidden = list(self._hidden_entities)
-        for actor, batch in self._batches.items():
-            ghosts = np.zeros(batch.mesh.n_cells, dtype=np.uint8)
-            if hidden:
-                ghosts[np.isin(batch.entity_ids, hidden)] = _HIDDEN_CELL
-            batch.mesh.cell_data[_GHOST_ARRAY] = ghosts
+    def _visible_geometry(self, mesh, entity_ids):
+        """Get the geometry of a merged mesh without the cells of hidden entities.
 
-        for outlines in self._element_edge_actors.values():
-            mesh = outlines.mapper.dataset
+        Parameters
+        ----------
+        mesh : pyvista.DataSet
+            Merged mesh to take the visible cells of.
+        entity_ids : np.ndarray
+            Entity ID of every cell of the merged mesh.
+
+        Returns
+        -------
+        pyvista.DataSet
+            The mesh itself when nothing it holds is hidden, and a copy holding only
+            the visible cells otherwise.
+        """
+        if not self._hidden_entities:
+            return mesh
+        hidden = np.isin(entity_ids, list(self._hidden_entities))
+        if not hidden.any():
+            return mesh
+        return mesh.extract_cells(np.flatnonzero(~hidden))
+
+    def _apply_visibility(self) -> None:
+        """Draw only the cells of the entities that are visible.
+
+        Cells cannot be masked in place: a ghost array is honored by the filters that
+        build a surface from a data set, not by the mapper of a polygonal mesh, so the
+        drawn geometry has to hold the visible cells and nothing else.
+        """
+        for actor, batch in self._batches.items():
+            actor.mapper.dataset = self._visible_geometry(batch.mesh, batch.entity_ids)
+
+        for part_id, outlines in self._element_edge_actors.items():
+            mesh = self._element_edge_meshes.get(part_id)
             if mesh is None or ENTITY_ID_ARRAY not in mesh.cell_data:
                 continue
-            ghosts = np.zeros(mesh.n_cells, dtype=np.uint8)
-            if hidden:
-                ghosts[np.isin(mesh.cell_data[ENTITY_ID_ARRAY], hidden)] = _HIDDEN_CELL
-            mesh.cell_data[_GHOST_ARRAY] = ghosts
+            outlines.mapper.dataset = self._visible_geometry(mesh, mesh.cell_data[ENTITY_ID_ARRAY])
+        self._update_entity_labels()
         self.render()
 
     def set_show_edges(self, show: bool) -> None:
@@ -562,7 +654,10 @@ class PrimePlotter(Plotter):
         self._batches = {}
         self._entity_infos = {}
         self._picked_entities = {}
+        self._picked_points = {}
+        self._entity_labels = {}
         self._hidden_entities = set()
+        self._element_edge_meshes = {}
         self._add_widgets()
 
     def add_scope(self, model: Model, scope: prime.ScopeDefinition, update: bool = False) -> None:

--- a/src/ansys/meshing/prime/graphics/widgets/color_by_type.py
+++ b/src/ansys/meshing/prime/graphics/widgets/color_by_type.py
@@ -21,42 +21,16 @@
 # SOFTWARE.
 
 """Module for ColorByTypeWidget."""
-import enum
 import os
 from typing import TYPE_CHECKING
 
-import numpy as np
 from ansys.tools.visualization_interface.backends.pyvista.widgets import PlotterWidget
 from vtk import vtkPNGReader
 
 if TYPE_CHECKING:
     from ansys.meshing.prime.graphics.plotter import PrimePlotter
 
-from ansys.meshing.prime.core.mesh import DisplayMeshInfo
-
-color_matrix = np.array(
-    [
-        [155, 186, 126],
-        [242, 236, 175],
-        [255, 187, 131],
-        [194, 187, 97],
-        [159, 131, 169],
-        [157, 190, 139],
-        [233, 218, 158],
-        [254, 252, 196],
-        [246, 210, 148],
-        [215, 208, 198],
-        [196, 235, 145],
-    ]
-)
-
-
-class ColorByType(enum.IntEnum):
-    """Contains the zone types to display."""
-
-    ZONE = 0
-    ZONELET = 1
-    PART = 2
+from ansys.meshing.prime.core.mesh import ColorByType, DisplayMeshInfo, entity_color
 
 
 class ColorByTypeWidget(PlotterWidget):
@@ -75,8 +49,6 @@ class ColorByTypeWidget(PlotterWidget):
         """Initialize the widget."""
         super().__init__(prime_plotter._backend._pl.scene)
         self.prime_plotter = prime_plotter
-        self._object_actors_map = self.prime_plotter._backend.pv_interface._object_to_actors_map
-        self._info_actor_map = self.prime_plotter._info_actor_map
         self._button = self.prime_plotter._backend.pv_interface.scene.add_checkbox_button_widget(
             self.callback, position=(5, 630), size=30, border_size=3
         )
@@ -86,11 +58,8 @@ class ColorByTypeWidget(PlotterWidget):
     def callback(self, state) -> None:
         """Define the callback function for the button widget."""
         color_type = ColorByType(self._button.GetRepresentation().GetState())
-        for actor, object in self._object_actors_map.items():
-            if actor in self.prime_plotter._info_actor_map:
-                mesh_info = self.prime_plotter._info_actor_map[actor]
-                actor.prop.color = self.set_color_by_type(color_type, mesh_info)
-                self.update(color_type)
+        self.prime_plotter.set_color_by_type(color_type)
+        self.update(color_type)
 
     def update(self, color_type=ColorByType.ZONE) -> None:
         """Define the configuration and representation of the button widget button.
@@ -132,10 +101,4 @@ class ColorByTypeWidget(PlotterWidget):
         List
             List of colors for faces.
         """
-        num_colors = int(color_matrix.size / 3)
-        if color_type == ColorByType.ZONELET:
-            return color_matrix[mesh_info.id % num_colors].tolist()
-        elif color_type == ColorByType.PART:
-            return color_matrix[mesh_info.part_id % num_colors].tolist()
-        else:
-            return color_matrix[mesh_info.zone_id % num_colors].tolist()
+        return entity_color(mesh_info, color_type).tolist()

--- a/src/ansys/meshing/prime/graphics/widgets/hide_picked.py
+++ b/src/ansys/meshing/prime/graphics/widgets/hide_picked.py
@@ -46,9 +46,6 @@ class HidePicked(PlotterWidget):
         """Initialize the widget."""
         super().__init__(prime_plotter._backend._pl.scene)
         self.prime_plotter = prime_plotter
-        self._picked_dict = self.prime_plotter._backend._custom_picker._picked_dict
-        self._object_actors_map = self.prime_plotter._backend._object_to_actors_map
-        self._element_edge_actors = self.prime_plotter._element_edge_actors
         self._button = self.prime_plotter._backend._pl.scene.add_checkbox_button_widget(
             self.callback,
             position=(5, 660),
@@ -57,26 +54,16 @@ class HidePicked(PlotterWidget):
             color_off="white",
             color_on="white",
         )
-        self._removed_actors = []
-
-    def _actors_of(self, meshobject) -> list:
-        """Get every actor that draws a mesh object, outlines included."""
-        actors = [meshobject.actor]
-        edge_actor = self._element_edge_actors.get(meshobject.actor)
-        if edge_actor is not None:
-            actors.append(edge_actor)
-        return actors
+        self._hidden_entities = []
 
     def callback(self, state: bool) -> None:
         """Define callback function for the button widget."""
         if state:
-            for meshobject in list(self._picked_dict.values()):
-                for actor in self._actors_of(meshobject):
-                    self.prime_plotter._backend.pv_interface.scene.remove_actor(actor)
-                    self._removed_actors.append(actor)
+            self._hidden_entities = [info.id for info in self.prime_plotter.selected_entity_infos]
+            self.prime_plotter.set_entities_visible(self._hidden_entities, False)
         else:
-            for actor in self._removed_actors:
-                self.prime_plotter._backend._pl.scene.add_actor(actor)
+            self.prime_plotter.set_entities_visible(self._hidden_entities, True)
+            self._hidden_entities = []
 
     def update(self) -> None:
         """Define the configuration and representation of the button widget button."""

--- a/src/ansys/meshing/prime/graphics/widgets/picked_info.py
+++ b/src/ansys/meshing/prime/graphics/widgets/picked_info.py
@@ -47,8 +47,6 @@ class PickedInfo(PlotterWidget):
         """Initialize widget."""
         super().__init__(prime_plotter._backend._pl.scene)
         self.prime_plotter = prime_plotter
-        self._picked_dict = self.prime_plotter._backend._custom_picker._picked_dict
-        self._object_actors_map = self.prime_plotter._backend._object_to_actors_map
         self._button = self.prime_plotter._backend._pl.scene.add_checkbox_button_widget(
             self.callback,
             position=(5, 570),
@@ -57,7 +55,6 @@ class PickedInfo(PlotterWidget):
             color_off="white",
             color_on="white",
         )
-        self._info_actor_map = self.prime_plotter._info_actor_map
 
     def info_message(self, mesh_info: DisplayMeshInfo) -> str:
         """Get the information message for the selected mesh object.
@@ -102,8 +99,7 @@ class PickedInfo(PlotterWidget):
         state : bool
             State of the button widget.
         """
-        for meshobject in list(self._picked_dict.values()):
-            mesh_info = self._info_actor_map[meshobject.actor]
+        for mesh_info in self.prime_plotter.selected_entity_infos:
             print(self.info_message(mesh_info))
 
     def update(self) -> None:

--- a/src/ansys/meshing/prime/graphics/widgets/toggle_edges.py
+++ b/src/ansys/meshing/prime/graphics/widgets/toggle_edges.py
@@ -43,7 +43,6 @@ class ToggleEdges(PlotterWidget):
         """Initialize the widget."""
         super().__init__(prime_plotter._backend._pl.scene)
         self.prime_plotter = prime_plotter
-        self._object_actors_map = self.prime_plotter._backend._object_to_actors_map
         self._button = self.prime_plotter._backend._pl.scene.add_checkbox_button_widget(
             self.callback,
             position=(5, 600),
@@ -52,8 +51,6 @@ class ToggleEdges(PlotterWidget):
             color_off="white",
             color_on="white",
         )
-        self._info_actor_map = self.prime_plotter._info_actor_map
-        self._element_edge_actors = self.prime_plotter._element_edge_actors
 
     def callback(self, state: bool) -> None:
         """Toggle the edges of the mesh objects.
@@ -63,13 +60,7 @@ class ToggleEdges(PlotterWidget):
         state : bool
             Whether the button widget is activated.
         """
-        for key, actor in self.prime_plotter._backend._pl.scene.actors.items():
-            if actor in self._info_actor_map and self._info_actor_map[actor].has_mesh:
-                actor.prop.show_edges = not state
-        # element outlines drawn as separate line geometry are hidden as a whole,
-        # since they are lines rather than the edges of a shaded actor
-        for actor in self._element_edge_actors.values():
-            actor.visibility = not state
+        self.prime_plotter.set_show_edges(not state)
 
     def update(self) -> None:
         """Define the configuration and representation of the button widget button."""

--- a/tests/core/test_mesh_scope.py
+++ b/tests/core/test_mesh_scope.py
@@ -1,0 +1,60 @@
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Tests for mesh visualization helpers."""
+
+import ansys.meshing.prime as prime
+
+
+def test_get_scoped_polydata_does_not_mutate_scope(initialized_model_elbow):
+    """Scoped queries must leave the caller's ScopeDefinition unchanged.
+
+    The query walks parts by temporarily narrowing ``part_expression``. Doing
+    that on the input object left later plots that reuse the same scope looking
+    at only the last part.
+    """
+    model, _ = initialized_model_elbow
+    scope = prime.ScopeDefinition(model, part_expression="*", label_expression="*")
+    before = (
+        scope.part_expression,
+        scope.label_expression,
+        scope.zone_expression,
+        scope.entity_type,
+        scope.evaluation_type,
+    )
+
+    first = model.get_scoped_polydata(scope)
+    assert before == (
+        scope.part_expression,
+        scope.label_expression,
+        scope.zone_expression,
+        scope.entity_type,
+        scope.evaluation_type,
+    )
+
+    # reusing the same scope must keep returning the same entities
+    second = model.get_scoped_polydata(scope)
+    assert set(first) == set(second)
+    for part_id in first:
+        assert {info.id for _, info in first[part_id]["faces"]} == {
+            info.id for _, info in second[part_id]["faces"]
+        }

--- a/tests/graphics/test_graphics.py
+++ b/tests/graphics/test_graphics.py
@@ -35,6 +35,7 @@ from ansys.meshing.prime.core.mesh import (
     compute_face_list_from_structured_nodes,
 )
 from ansys.meshing.prime.graphics import PrimePlotter
+from ansys.meshing.prime.graphics.widgets.hide_picked import HidePicked
 
 pv.OFF_SCREEN = True
 IMAGE_RESULTS_DIR = Path(Path(__file__).parent, "image_cache", "results")
@@ -82,7 +83,9 @@ def _check_element_outlines(model_pd):
 
 def _mesh_elbow(model, mixing_elbow, quadratic):
     """Volume mesh the mixing elbow in an empty model and return its polydata."""
-    model.delete_parts([part.id for part in model.parts])
+    part_ids = [part.id for part in model.parts]
+    if part_ids:
+        model.delete_parts(part_ids)
     mesh_util = prime.lucid.Mesh(model=model)
     mesh_util.read(mixing_elbow)
     mesh_util.surface_mesh(min_size=5, max_size=20)
@@ -122,6 +125,17 @@ def test_quadratic_element_outlines(get_remote_client, get_examples):
         for actor in outlines.values():
             outlined |= set(actor.mapper.dataset.cell_data[ENTITY_ID_ARRAY].tolist())
         assert len(outlined) == expected
+
+        # hiding an entity takes its outlines out of the scene together with its faces
+        hidden_id = sorted(outlined)[0]
+        display.set_entities_visible([hidden_id], False)
+        for actor in outlines.values():
+            drawn = actor.mapper.dataset
+            assert hidden_id not in set(drawn.cell_data[ENTITY_ID_ARRAY].tolist())
+        display.set_entities_visible([hidden_id], True)
+        for actor in outlines.values():
+            drawn = actor.mapper.dataset
+            assert hidden_id in set(drawn.cell_data[ENTITY_ID_ARRAY].tolist())
     finally:
         display.scene.close()
 
@@ -268,22 +282,170 @@ def test_pick_resolves_to_the_entity_under_the_point(get_remote_client, get_exam
 
 
 def test_hiding_an_entity_leaves_the_rest_drawn(get_remote_client, get_examples):
-    """Hiding an entity masks only its own cells of the mesh it shares."""
+    """Hiding an entity drops its cells from what is drawn, and only its own.
+
+    A cell of a shared mesh cannot be hidden by flagging it: the ghost array is
+    honored when a surface is built from a data set, not by the mapper of a
+    polygonal mesh, so the drawn geometry has to hold the visible cells only.
+    """
     model = get_remote_client.model
     model_pd = _mesh_elbow(model, get_examples["elbow_lucid"], quadratic=False)
 
     display = _plot_model(model_pd)
     try:
-        batch = max(display._batches.values(), key=lambda candidate: len(candidate.infos))
+        actor, batch = max(display._batches.items(), key=lambda item: len(item[1].infos))
         entity_id = int(batch.entity_ids[0])
+        hidden_cells = int(np.count_nonzero(batch.entity_ids == entity_id))
+        assert 0 < hidden_cells < batch.mesh.n_cells
 
         display.set_entities_visible([entity_id], False)
-        ghosts = batch.mesh.cell_data["vtkGhostType"]
-        assert (ghosts != 0).all(where=batch.entity_ids == entity_id)
-        assert not (ghosts != 0).any(where=batch.entity_ids != entity_id)
+        drawn = actor.mapper.dataset
+        assert drawn.n_cells == batch.mesh.n_cells - hidden_cells
+        assert entity_id not in set(drawn.cell_data[ENTITY_ID_ARRAY].tolist())
+        # the entity is only masked from the scene, never lost
+        assert batch.mesh.n_cells == drawn.n_cells + hidden_cells
+        assert entity_id in batch.infos
 
         display.set_entities_visible([entity_id], True)
-        assert not batch.mesh.cell_data["vtkGhostType"].any()
+        assert actor.mapper.dataset.n_cells == batch.mesh.n_cells
+        assert entity_id in set(actor.mapper.dataset.cell_data[ENTITY_ID_ARRAY].tolist())
+    finally:
+        display.scene.close()
+
+
+def test_hidden_entities_stay_hidden_when_recolored(get_remote_client, get_examples):
+    """Recoloring rebuilds the drawn geometry, which must stay free of hidden cells."""
+    model = get_remote_client.model
+    model_pd = _mesh_elbow(model, get_examples["elbow_lucid"], quadratic=False)
+
+    display = _plot_model(model_pd)
+    try:
+        actor, batch = max(display._batches.items(), key=lambda item: len(item[1].infos))
+        entity_id = int(batch.entity_ids[0])
+        display.set_entities_visible([entity_id], False)
+        drawn_cells = actor.mapper.dataset.n_cells
+
+        display.set_color_by_type(ColorByType.ZONELET)
+        drawn = actor.mapper.dataset
+        assert drawn.n_cells == drawn_cells
+        assert entity_id not in set(drawn.cell_data[ENTITY_ID_ARRAY].tolist())
+        # the drawn copy carries the colors that were just computed
+        assert ENTITY_COLOR_ARRAY in drawn.cell_data
+    finally:
+        display.scene.close()
+
+
+def test_hidden_entities_cannot_be_picked(get_remote_client, get_examples):
+    """A pick resolves against what is drawn, so hidden entities are not selectable."""
+    model = get_remote_client.model
+    model_pd = _mesh_elbow(model, get_examples["elbow_lucid"], quadratic=False)
+
+    display = _plot_model(model_pd)
+    try:
+        actor, batch = max(display._batches.items(), key=lambda item: len(item[1].infos))
+        entity_id = int(batch.entity_ids[0])
+        center = batch.mesh.cell_centers().points[0]
+
+        display.set_entities_visible([entity_id], False)
+        assert display._pick_entity(actor, center)
+        assert entity_id not in {int(info.id) for info in display.selected_entity_infos}
+    finally:
+        display.scene.close()
+
+
+def _pick_display_point(display, world_point):
+    """Pick the scene where a world point is drawn, the way a click does."""
+    scene = display.scene
+    coordinate = pv._vtk.vtkCoordinate()
+    coordinate.SetCoordinateSystemToWorld()
+    coordinate.SetValue(*world_point)
+    x, y = coordinate.GetComputedDisplayValue(scene.renderer)
+    scene.iren.picker.Pick(x, y, 0, scene.renderer)
+
+
+def test_clicking_a_shared_actor_selects_and_labels_an_entity(get_remote_client, get_examples):
+    """A click travels from the backend picker to the entity under the cursor.
+
+    The entities of a part share an actor, so the pick has to be resolved against
+    the cell it landed on, and the picked entity has to be labeled here, since the
+    generic backend can only label an object that owns an actor of its own.
+    """
+    model = get_remote_client.model
+    model_pd = _mesh_elbow(model, get_examples["elbow_lucid"], quadratic=False)
+
+    display = PrimePlotter(allow_picking=True)
+    try:
+        display.add_model_pd(model_pd)
+        display._backend.enable_picking()
+        display.scene.show(auto_close=False)
+        display.scene.render()
+
+        actor, batch = max(display._batches.items(), key=lambda item: len(item[1].infos))
+        _pick_display_point(display, batch.mesh.cell_centers().points[0])
+        picked_point = display.scene.picked_point
+        assert picked_point is not None, "the click has to land on the model"
+
+        drawn = display.scene._picked_actor.mapper.dataset
+        expected = int(
+            drawn.cell_data[ENTITY_ID_ARRAY][drawn.find_closest_cell(list(picked_point))]
+        )
+        assert [int(info.id) for info in display.selected_entity_infos] == [expected]
+
+        # the entity is named on screen, as an individually drawn object would be
+        assert expected in display._entity_labels
+        assert display._entity_labels[expected] in display.scene.actors.values()
+
+        # clicking it again clears both the selection and its label
+        _pick_display_point(display, batch.mesh.cell_centers().points[0])
+        assert display.selected_entity_infos == []
+        assert display._entity_labels == {}
+    finally:
+        display.scene.close()
+
+
+def test_hiding_a_picked_entity_hides_its_label(get_remote_client, get_examples):
+    """The label of an entity follows the entity in and out of the scene."""
+    model = get_remote_client.model
+    model_pd = _mesh_elbow(model, get_examples["elbow_lucid"], quadratic=False)
+
+    display = PrimePlotter(allow_picking=True)
+    try:
+        display.add_model_pd(model_pd)
+        actor, batch = max(display._batches.items(), key=lambda item: len(item[1].infos))
+        entity_id = int(batch.entity_ids[0])
+        display._pick_entity(actor, batch.mesh.cell_centers().points[0])
+        assert entity_id in display._entity_labels
+
+        display.set_entities_visible([entity_id], False)
+        assert display._entity_labels == {}
+        # the entity stays picked, so the widgets keep reporting it
+        assert [int(info.id) for info in display.selected_entity_infos] == [entity_id]
+
+        display.set_entities_visible([entity_id], True)
+        assert entity_id in display._entity_labels
+    finally:
+        display.scene.close()
+
+
+def test_hide_picked_widget_hides_and_restores_entities(get_remote_client, get_examples):
+    """The hide widget takes the picked entities out of the scene and brings them back."""
+    model = get_remote_client.model
+    model_pd = _mesh_elbow(model, get_examples["elbow_lucid"], quadratic=False)
+
+    display = PrimePlotter(allow_picking=True)
+    try:
+        display.add_model_pd(model_pd)
+        actor, batch = max(display._batches.items(), key=lambda item: len(item[1].infos))
+        entity_id = int(batch.entity_ids[0])
+        hidden_cells = int(np.count_nonzero(batch.entity_ids == entity_id))
+        display._pick_entity(actor, batch.mesh.cell_centers().points[0])
+
+        widget = next(w for w in display._backend._widgets if isinstance(w, HidePicked))
+        widget.callback(True)
+        assert actor.mapper.dataset.n_cells == batch.mesh.n_cells - hidden_cells
+
+        widget.callback(False)
+        assert actor.mapper.dataset.n_cells == batch.mesh.n_cells
     finally:
         display.scene.close()
 

--- a/tests/graphics/test_graphics.py
+++ b/tests/graphics/test_graphics.py
@@ -123,18 +123,18 @@ def test_quadratic_element_outlines(get_remote_client, get_examples):
         # every zonelet that holds outlines is still identifiable within them
         outlined = set()
         for actor in outlines.values():
-            outlined |= set(actor.mapper.dataset.cell_data[ENTITY_ID_ARRAY].tolist())
+            outlined |= set(display._drawn_geometry[actor].cell_data[ENTITY_ID_ARRAY].tolist())
         assert len(outlined) == expected
 
         # hiding an entity takes its outlines out of the scene together with its faces
         hidden_id = sorted(outlined)[0]
         display.set_entities_visible([hidden_id], False)
         for actor in outlines.values():
-            drawn = actor.mapper.dataset
+            drawn = display._drawn_geometry[actor]
             assert hidden_id not in set(drawn.cell_data[ENTITY_ID_ARRAY].tolist())
         display.set_entities_visible([hidden_id], True)
         for actor in outlines.values():
-            drawn = actor.mapper.dataset
+            drawn = display._drawn_geometry[actor]
             assert hidden_id in set(drawn.cell_data[ENTITY_ID_ARRAY].tolist())
     finally:
         display.scene.close()
@@ -225,6 +225,12 @@ def _plot_model(model_pd):
     return display
 
 
+def _drawn_pixels(display):
+    """Count the pixels the model is drawn on, from a camera that does not move."""
+    image = np.asarray(display.scene.screenshot())
+    return int(np.count_nonzero((image != 255).any(axis=2)))
+
+
 def test_entities_of_a_part_share_actors(get_remote_client, get_examples):
     """A part is drawn with a handful of actors however many entities it holds.
 
@@ -297,18 +303,26 @@ def test_hiding_an_entity_leaves_the_rest_drawn(get_remote_client, get_examples)
         entity_id = int(batch.entity_ids[0])
         hidden_cells = int(np.count_nonzero(batch.entity_ids == entity_id))
         assert 0 < hidden_cells < batch.mesh.n_cells
+        # the first screenshot of a window only sets it up, so it can come back blank
+        display.scene.screenshot()
+        everything = _drawn_pixels(display)
 
         display.set_entities_visible([entity_id], False)
-        drawn = actor.mapper.dataset
+        drawn = display._drawn_geometry[actor]
         assert drawn.n_cells == batch.mesh.n_cells - hidden_cells
         assert entity_id not in set(drawn.cell_data[ENTITY_ID_ARRAY].tolist())
         # the entity is only masked from the scene, never lost
         assert batch.mesh.n_cells == drawn.n_cells + hidden_cells
         assert entity_id in batch.infos
+        # the mapper keeps no reference of its own to what it draws, so the geometry
+        # has to be checked on screen and not only in the state of the plotter
+        assert 0 < _drawn_pixels(display) < everything
 
         display.set_entities_visible([entity_id], True)
-        assert actor.mapper.dataset.n_cells == batch.mesh.n_cells
-        assert entity_id in set(actor.mapper.dataset.cell_data[ENTITY_ID_ARRAY].tolist())
+        assert display._drawn_geometry[actor].n_cells == batch.mesh.n_cells
+        assert entity_id in set(display._drawn_geometry[actor].cell_data[ENTITY_ID_ARRAY].tolist())
+        # showing the entity again has to bring every pixel of it back
+        assert _drawn_pixels(display) == everything
     finally:
         display.scene.close()
 
@@ -323,10 +337,10 @@ def test_hidden_entities_stay_hidden_when_recolored(get_remote_client, get_examp
         actor, batch = max(display._batches.items(), key=lambda item: len(item[1].infos))
         entity_id = int(batch.entity_ids[0])
         display.set_entities_visible([entity_id], False)
-        drawn_cells = actor.mapper.dataset.n_cells
+        drawn_cells = display._drawn_geometry[actor].n_cells
 
         display.set_color_by_type(ColorByType.ZONELET)
-        drawn = actor.mapper.dataset
+        drawn = display._drawn_geometry[actor]
         assert drawn.n_cells == drawn_cells
         assert entity_id not in set(drawn.cell_data[ENTITY_ID_ARRAY].tolist())
         # the drawn copy carries the colors that were just computed
@@ -385,7 +399,7 @@ def test_clicking_a_shared_actor_selects_and_labels_an_entity(get_remote_client,
         picked_point = display.scene.picked_point
         assert picked_point is not None, "the click has to land on the model"
 
-        drawn = display.scene._picked_actor.mapper.dataset
+        drawn = display._drawn_geometry[display.scene.picked_actor]
         expected = int(
             drawn.cell_data[ENTITY_ID_ARRAY][drawn.find_closest_cell(list(picked_point))]
         )
@@ -442,10 +456,10 @@ def test_hide_picked_widget_hides_and_restores_entities(get_remote_client, get_e
 
         widget = next(w for w in display._backend._widgets if isinstance(w, HidePicked))
         widget.callback(True)
-        assert actor.mapper.dataset.n_cells == batch.mesh.n_cells - hidden_cells
+        assert display._drawn_geometry[actor].n_cells == batch.mesh.n_cells - hidden_cells
 
         widget.callback(False)
-        assert actor.mapper.dataset.n_cells == batch.mesh.n_cells
+        assert display._drawn_geometry[actor].n_cells == batch.mesh.n_cells
     finally:
         display.scene.close()
 

--- a/tests/graphics/test_graphics.py
+++ b/tests/graphics/test_graphics.py
@@ -28,6 +28,9 @@ import pyvista as pv
 
 import ansys.meshing.prime as prime
 from ansys.meshing.prime.core.mesh import (
+    ENTITY_COLOR_ARRAY,
+    ENTITY_ID_ARRAY,
+    ColorByType,
     compute_distance,
     compute_face_list_from_structured_nodes,
 )
@@ -111,12 +114,14 @@ def test_quadratic_element_outlines(get_remote_client, get_examples):
     try:
         display.add_model_pd(quadratic_pd)
         outlines = display.element_edge_actors
-        assert len(outlines) == expected
+        # the outlines of a part are drawn together, so they are keyed by part
+        assert set(outlines) <= set(quadratic_pd)
         assert all(actor.visibility for actor in outlines.values())
-        # every outline is keyed by the face actor it belongs to, so that hiding a
-        # zonelet hides its outlines too
-        face_actors = [actor for actor in display.info_actor_map if actor in outlines]
-        assert len(face_actors) == expected
+        # every zonelet that holds outlines is still identifiable within them
+        outlined = set()
+        for actor in outlines.values():
+            outlined |= set(actor.mapper.dataset.cell_data[ENTITY_ID_ARRAY].tolist())
+        assert len(outlined) == expected
     finally:
         display.scene.close()
 
@@ -197,6 +202,114 @@ def test_quadratic_tet_plotter(get_remote_client, get_examples, verify_image_cac
     scene.camera_position = [tuple(target + direction * span * 1.6), tuple(target), (0, 0, 1)]
     scene.camera.zoom(2.4)
     display.show()
+
+
+def _plot_model(model_pd):
+    """Plot polydata and return the plotter."""
+    display = PrimePlotter(allow_picking=False)
+    display.add_model_pd(model_pd)
+    return display
+
+
+def test_entities_of_a_part_share_actors(get_remote_client, get_examples):
+    """A part is drawn with a handful of actors however many entities it holds.
+
+    The cost of a scene, and of exporting one, scales with the number of actors,
+    so entity count must not leak into it.
+    """
+    model = get_remote_client.model
+    model_pd = _mesh_elbow(model, get_examples["elbow_lucid"], quadratic=False)
+
+    # the widget buttons are actors of their own, so only count what the model adds
+    empty = PrimePlotter(allow_picking=False)
+    baseline = len(empty.scene.actors)
+    empty.scene.close()
+
+    display = _plot_model(model_pd)
+    try:
+        entities = sum(len(part_pd["faces"]) for part_pd in model_pd.values())
+        model_actors = len(display.scene.actors) - baseline
+        # at most two face batches, one outline actor, and one edge actor per part
+        assert model_actors <= 4 * len(model_pd)
+        assert model_actors < entities
+        # merging must not lose any entity
+        assert len(display.entity_infos) == entities
+    finally:
+        display.scene.close()
+
+
+def test_pick_resolves_to_the_entity_under_the_point(get_remote_client, get_examples):
+    """Picking a shared actor selects the one entity the point falls on."""
+    model = get_remote_client.model
+    model_pd = _mesh_elbow(model, get_examples["elbow_lucid"], quadratic=False)
+
+    display = _plot_model(model_pd)
+    try:
+        actor, batch = max(display._batches.items(), key=lambda item: len(item[1].infos))
+        assert len(batch.infos) > 1, "need a batch holding several entities"
+
+        centers = batch.mesh.cell_centers().points
+        for cell_id in (0, batch.mesh.n_cells // 2, batch.mesh.n_cells - 1):
+            expected = int(batch.entity_ids[cell_id])
+            display._picked_entities.clear()
+            assert display._pick_entity(actor, centers[cell_id])
+            assert [int(info.id) for info in display.selected_entity_infos] == [expected]
+
+            # the picked entity is highlighted, and only it
+            colors = batch.mesh.cell_data[ENTITY_COLOR_ARRAY]
+            highlighted = np.unique(batch.entity_ids[colors[:, 0] == colors[cell_id][0]])
+            assert set(highlighted.tolist()) == {expected}
+
+            # picking it again clears the selection
+            assert display._pick_entity(actor, centers[cell_id])
+            assert display.selected_entity_infos == []
+    finally:
+        display.scene.close()
+
+
+def test_hiding_an_entity_leaves_the_rest_drawn(get_remote_client, get_examples):
+    """Hiding an entity masks only its own cells of the mesh it shares."""
+    model = get_remote_client.model
+    model_pd = _mesh_elbow(model, get_examples["elbow_lucid"], quadratic=False)
+
+    display = _plot_model(model_pd)
+    try:
+        batch = max(display._batches.values(), key=lambda candidate: len(candidate.infos))
+        entity_id = int(batch.entity_ids[0])
+
+        display.set_entities_visible([entity_id], False)
+        ghosts = batch.mesh.cell_data["vtkGhostType"]
+        assert (ghosts != 0).all(where=batch.entity_ids == entity_id)
+        assert not (ghosts != 0).any(where=batch.entity_ids != entity_id)
+
+        display.set_entities_visible([entity_id], True)
+        assert not batch.mesh.cell_data["vtkGhostType"].any()
+    finally:
+        display.scene.close()
+
+
+def test_color_by_type_recolors_shared_meshes(get_remote_client, get_examples):
+    """Switching color mode recolors cells rather than actors."""
+    model = get_remote_client.model
+    model_pd = _mesh_elbow(model, get_examples["elbow_lucid"], quadratic=False)
+
+    display = _plot_model(model_pd)
+    try:
+        batch = max(display._batches.values(), key=lambda candidate: len(candidate.infos))
+
+        display.set_color_by_type(ColorByType.PART)
+        by_part = batch.mesh.cell_data[ENTITY_COLOR_ARRAY].copy()
+        assert len(np.unique(by_part, axis=0)) == 1
+
+        display.set_color_by_type(ColorByType.ZONELET)
+        by_zonelet = batch.mesh.cell_data[ENTITY_COLOR_ARRAY]
+        assert len(np.unique(by_zonelet, axis=0)) > 1
+        # cells of one entity always share a color
+        for entity_id in list(batch.infos)[:5]:
+            cells = batch.entity_ids == entity_id
+            assert len(np.unique(by_zonelet[cells], axis=0)) == 1
+    finally:
+        display.scene.close()
 
 
 def test_compute_distance():


### PR DESCRIPTION
- Draw the display entities of a part with a handful of shared actors instead of one actor each, so that scenes with many zonelets render and export in a fraction of the time.
- Leave ``ScopeDefinition`` objects unchanged when evaluating scoped polydata, so reusing a scope across plots no longer silently narrows to the last part.
