### PR TITLE
fix: changes from ansys-tools-common

### DIFF
--- a/doc/changelog.d/1352.fixed.md
+++ b/doc/changelog.d/1352.fixed.md
@@ -1,0 +1,1 @@
+Fix: changes from ansys-tools-common

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,10 +128,15 @@ def get_examples():
 
 @pytest.fixture(scope="session", autouse=True)
 def get_testfiles():
-    """Downloads unit test files"""
-    if not os.path.exists("./tests/core/test_files/"):
-        os.mkdir(os.path.abspath("./tests/core/test_files/"))
-    download_test_examples(destination=str(os.path.abspath("./tests/core/test_files/")))
+    """Download unit test files and return a map of filename to local path.
+
+    ``DownloadManager`` nests files under the GitHub directory name, so callers
+    must use the returned paths rather than ``destination / filename``.
+    """
+    destination = os.path.abspath("./tests/core/test_files/")
+    os.makedirs(destination, exist_ok=True)
+    paths = download_test_examples(destination=destination)
+    return {os.path.basename(path): path for path in paths}
 
 
 def create_scenario_element(test, id):

--- a/tests/core/test_fileio.py
+++ b/tests/core/test_fileio.py
@@ -45,7 +45,7 @@ def test_io_file_not_found_error(get_remote_client, get_examples):
             )
 
 
-def test_io_pdmat(get_remote_client, get_examples, tmp_path):
+def test_io_pdmat(get_remote_client, get_examples, get_testfiles, tmp_path):
     model = get_remote_client.model
     file_io = prime.FileIO(model=model)
     file_read_params = prime.FileReadParams(model=model)
@@ -54,7 +54,7 @@ def test_io_pdmat(get_remote_client, get_examples, tmp_path):
     # Wrong extension
     with pytest.raises(PrimeRuntimeError) as prime_error:
         _ = file_io.read_pmdat(
-            os.path.abspath("./tests/core/test_files/file.pdmat"),
+            get_testfiles["file.pdmat"],
             file_read_params,
         )
         assert "file extension is not supported" in str(prime_error.value)
@@ -62,7 +62,7 @@ def test_io_pdmat(get_remote_client, get_examples, tmp_path):
     # Empty file
     with pytest.raises(PrimeRuntimeError) as prime_error:
         _ = file_io.read_pmdat(
-            os.path.abspath("./tests/core/test_files/file.pmdat"),
+            get_testfiles["file.pmdat"],
             file_read_params,
         )
 
@@ -82,15 +82,13 @@ def test_io_pdmat(get_remote_client, get_examples, tmp_path):
     assert results.error_code == ErrorCode.NOERROR
 
 
-def test_io_cdb(get_remote_client, tmp_path):
+def test_io_cdb(get_remote_client, get_testfiles, tmp_path):
     model = get_remote_client.model
     file_io = prime.FileIO(model=model)
 
     # import
     import_params = prime.ImportMapdlCdbParams(model=model)
-    results = file_io.import_mapdl_cdb(
-        os.path.abspath("./tests/core/test_files/hex.cdb"), import_params
-    )
+    results = file_io.import_mapdl_cdb(get_testfiles["hex.cdb"], import_params)
     assert results.error_code == ErrorCode.NOERROR
 
     # export
@@ -100,15 +98,13 @@ def test_io_cdb(get_remote_client, tmp_path):
     assert results.error_code == ErrorCode.NOERROR
 
 
-def test_io_fluent_case(get_remote_client, tmp_path):
+def test_io_fluent_case(get_remote_client, get_testfiles, tmp_path):
     model = get_remote_client.model
     file_io = prime.FileIO(model=model)
 
     # import
     import_params = prime.ImportFluentCaseParams(model=model)
-    results = file_io.import_fluent_case(
-        os.path.abspath("./tests/core/test_files/hex.cas"), import_params
-    )
+    results = file_io.import_fluent_case(get_testfiles["hex.cas"], import_params)
     assert results.error_code == ErrorCode.NOERROR
 
     # export
@@ -135,25 +131,21 @@ def test_export_kfile(get_remote_client, get_examples, tmp_path):
     assert results.error_code == ErrorCode.NOERROR
 
 
-def test_io_sf(get_remote_client):
+def test_io_sf(get_remote_client, get_testfiles):
     model = get_remote_client.model
     file_io = prime.FileIO(model=model)
 
     # import
-    results = file_io.import_fluent_meshing_size_field(
-        os.path.abspath("./tests/core/test_files/box.sf")
-    )
+    results = file_io.import_fluent_meshing_size_field(get_testfiles["box.sf"])
     assert results.error_code == ErrorCode.NOERROR
 
 
-def test_io_psf(get_remote_client, tmp_path):
+def test_io_psf(get_remote_client, get_testfiles, tmp_path):
     model = get_remote_client.model
     file_io = prime.FileIO(model=model)
 
     import_params = prime.ReadSizeFieldParams(model=model)
-    results = file_io.read_size_field(
-        os.path.abspath("./tests/core/test_files/box.psf"), import_params
-    )
+    results = file_io.read_size_field(get_testfiles["box.psf"], import_params)
     assert results.error_code == ErrorCode.NOERROR
 
     export_params = prime.WriteSizeFieldParams(model=model)
@@ -162,22 +154,22 @@ def test_io_psf(get_remote_client, tmp_path):
     assert results.error_code == ErrorCode.NOERROR
 
 
-def test_io_cad(get_remote_client):
+def test_io_cad(get_remote_client, get_testfiles):
     model = get_remote_client.model
     file_io = prime.FileIO(model=model)
 
     import_params = prime.ImportCadParams(model=model)
-    results = file_io.import_cad(os.path.abspath("./tests/core/test_files/hex.fmd"), import_params)
+    results = file_io.import_cad(get_testfiles["hex.fmd"], import_params)
     assert results.error_code == ErrorCode.NOERROR
 
 
-def test_io_fluent_mesh(get_remote_client, tmp_path):
+def test_io_fluent_mesh(get_remote_client, get_testfiles, tmp_path):
     model = get_remote_client.model
     file_io = prime.FileIO(model=model)
 
     import_params = prime.ImportFluentMeshingMeshParams(model=model)
     results = file_io.import_fluent_meshing_meshes(
-        [os.path.abspath("./tests/core/test_files/hex.msh")], import_params
+        [get_testfiles["hex.msh"]], import_params
     )
     assert results.error_code == ErrorCode.NOERROR
 

--- a/tests/core/test_fileio.py
+++ b/tests/core/test_fileio.py
@@ -168,9 +168,7 @@ def test_io_fluent_mesh(get_remote_client, get_testfiles, tmp_path):
     file_io = prime.FileIO(model=model)
 
     import_params = prime.ImportFluentMeshingMeshParams(model=model)
-    results = file_io.import_fluent_meshing_meshes(
-        [get_testfiles["hex.msh"]], import_params
-    )
+    results = file_io.import_fluent_meshing_meshes([get_testfiles["hex.msh"]], import_params)
     assert results.error_code == ErrorCode.NOERROR
 
     import_params = prime.ExportFluentMeshingMeshParams(model=model)

--- a/tests/lucid/test_mesh_utils.py
+++ b/tests/lucid/test_mesh_utils.py
@@ -34,13 +34,13 @@ def mesh(get_remote_client):
     return mesh
 
 
-def test_read(mesh):
-    mesh.read(os.path.abspath("./tests/core/test_files/hex.msh"))
-    mesh.read(os.path.abspath("./tests/core/test_files/hex.cdb"))
-    mesh.read(os.path.abspath("./tests/core/test_files/hex.cas"))
+def test_read(mesh, get_testfiles):
+    mesh.read(get_testfiles["hex.msh"])
+    mesh.read(get_testfiles["hex.cdb"])
+    mesh.read(get_testfiles["hex.cas"])
 
     # causes docker error
-    # mesh.read(os.path.abspath("./tests/core/test_files/file.pmdat"))
+    # mesh.read(get_testfiles["file.pmdat"])
     # missing CAD file
 
 
@@ -58,12 +58,12 @@ def test_write(mesh, tmp_path):
     mesh.read(os.path.abspath(str(tmp_path) + "/file_output.pmdat"))
 
 
-def test_create_zones(mesh, get_examples):
+def test_create_zones(mesh, get_examples, get_testfiles):
     pmdat_path = get_examples["elbow_lucid"]
     mesh.read(pmdat_path)
     mesh.create_zones_from_labels(label_expression="*")
     mesh.create_zones_from_labels(conversion_method=1)
-    mesh.read(os.path.abspath("./tests/core/test_files/hex.cas"))
+    mesh.read(get_testfiles["hex.cas"])
     mesh.create_zones_from_labels(label_expression="*")
 
 


### PR DESCRIPTION
## Description
`ansys-tools-common` 0.5.3 nested example downloads under the GitHub directory name (`destination/pyprimemesh/unit_test_examples/<file>`). File I/O tests still opened `./tests/core/test_files/<file>`, so those assets were not found.

`get_testfiles` now returns a filename-to-path map from `download_test_examples()`, and the FileIO / lucid tests use that map instead of hardcoded relative paths. `test_export_kfile` was already doing this via `get_examples` and did not need a change.

## Issue linked
CI failures in:
- `tests/core/test_fileio.py` (`test_io_pdmat`, `test_io_cdb`, `test_io_fluent_case`, `test_io_sf`, `test_io_psf`, `test_io_cad`, `test_io_fluent_mesh`)
- `tests/lucid/test_mesh_utils.py` (`test_read`, `test_create_zones`)