### PR TITLE
feat: improve PrimeRuntimeError.__repr__

### DIFF
--- a/doc/changelog.d/1353.added.md
+++ b/doc/changelog.d/1353.added.md
@@ -1,0 +1,1 @@
+Feat: improve PrimeRuntimeError.__repr__

--- a/src/ansys/meshing/prime/internals/error_handling.py
+++ b/src/ansys/meshing/prime/internals/error_handling.py
@@ -494,6 +494,16 @@ class PrimeRuntimeError(Exception):
         """Transform the message to a string."""
         return self._message
 
+    def __repr__(self) -> str:
+        """Provide the full string representation of the error."""
+        args = [f"message={self._message!r}"]
+        # Skip default arguments
+        if self._error_code is not None:
+            args.append(f"error_code={self._error_code!r}")
+        if self._error_locations is not None:
+            args.append(f"error_locations={self._error_locations!r}")
+        return f"{self.__class__.__name__}({', '.join(args)})"
+
     def __process_message(self, message: str):
         """Process the message to be digested by the error class.
 

--- a/tests/core/test_fileio.py
+++ b/tests/core/test_fileio.py
@@ -58,7 +58,7 @@ def test_io_pdmat(get_remote_client, get_examples, get_testfiles, tmp_path):
             file_read_params,
         )
         assert "file extension is not supported" in str(prime_error.value)
-        assert "file extension is not supported" in repr(prime_error.value)
+        assert "file extension is not supported" in repr(prime_error)
 
     # Empty file
     with pytest.raises(PrimeRuntimeError) as prime_error:

--- a/tests/core/test_fileio.py
+++ b/tests/core/test_fileio.py
@@ -58,6 +58,7 @@ def test_io_pdmat(get_remote_client, get_examples, get_testfiles, tmp_path):
             file_read_params,
         )
         assert "file extension is not supported" in str(prime_error.value)
+        assert "file extension is not supported" in repr(prime_error.value)
 
     # Empty file
     with pytest.raises(PrimeRuntimeError) as prime_error:


### PR DESCRIPTION
## Description
Implement a more complete __repr__ method for the PrimeRuntimeError class.

Previously, the error details were swallowed in the __repr__ method, which goes against the spirit of providing a complete representation of the object.

## Issue linked
N/A

## Checklist
- [x] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate unit tests.
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved to the PR if any.
- [x] I have assigned this PR to myself.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: wrap with feature edges``)
